### PR TITLE
Adjust kitty related settings

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -45,6 +45,11 @@ if [ -d "$HOME/Go" ]
     set_path "$GOPATH/bin"
 end
 
+# Configure kitty
+if type -q kitty
+    alias ssh="TERM=xterm-256color $(which ssh)"
+end
+
 # Configure fzf
 if type -q fzf
     set -U FZF_LEGACY_KEYBINDINGS 0

--- a/config/nixpkgs/programs/kitty.nix
+++ b/config/nixpkgs/programs/kitty.nix
@@ -43,6 +43,10 @@
 
       background_opacity = "0.9";
 
+      remember_window_size = "no";
+      initial_window_width = 640;
+      initial_window_height = 400;
+
       kitty_mod = "ctrl+shift";
       scrollback_lines = 100000;
       confirm_os_window_close = 0;


### PR DESCRIPTION
- Fix TERM="xterm-kitty" problem on ssh remote host
- Add the default window size parameters for the kitty