### PR TITLE
Change extension for C++ used in VS Code

### DIFF
--- a/config/home-manager/programs/vscode/extensions
+++ b/config/home-manager/programs/vscode/extensions
@@ -28,6 +28,7 @@ janisdd.vscode-edit-csv
 jnoortheen.nix-ide
 justusadam.language-haskell
 kamikillerto.vscode-colorize
+llvm-vs-code-extensions.vscode-clangd
 lokalise.i18n-ally
 mathiasfrohlich.Kotlin
 mattn.Lisp
@@ -40,8 +41,6 @@ ms-toolsai.jupyter-renderers
 ms-vscode-remote.remote-ssh
 ms-vscode-remote.remote-ssh-edit
 ms-vscode.cmake-tools
-ms-vscode.cpptools
-ms-vscode.cpptools-themes
 ms-vscode.makefile-tools
 ms-vscode.remote-explorer
 nwolverson.ide-purescript


### PR DESCRIPTION
- from `ms-vscode.cpptools` to `llvm-vs-code-extensions.vscode-clangd`