### PR TITLE
Update VS Code environments

### DIFF
--- a/config/home-manager/programs/vscode/default.nix
+++ b/config/home-manager/programs/vscode/default.nix
@@ -17,12 +17,12 @@ let
 
   archive_fmt = if pkgs.stdenv.isDarwin then "zip" else "tar.gz";
 
-  commit = "901ac65ea9f906d6996ad8e7639ba81acecf1d7c";
+  commit = "8fa84589eef3538dbc763ff98dc7d5a8a0c56374";
 
   sha256 = {
-    x86_64-linux = "1vmbck3xng8qbph61hhhyn4ay1xxpzinrdnnh07yqbsr9xb19p56";
-    x86_64-darwin = "0xln95lzy76ym2ckfnnkv6m7q9rdx8dm8n97dcnii0lf4dpcsrb9";
-    aarch64-darwin = "0c7594pv5rf4ryv37i6ny7w7lgjra579gbvfpyfy5l3xifmb2wxs";
+    x86_64-linux = "16v2v0rv2jrd1rsynx1yhn9093q2px8w8c8lxh0dn63w8dk901yw";
+    x86_64-darwin = "1xa9i2fj3ghkslqigf3x148p61l5fw9qs53s02kka4s3rwd0f4wq";
+    aarch64-darwin = "087dz88xc5pbsgrhq2172a6hnl4bb9im67qmpdsnac1xi72z38hk";
   }.${system};
   # End of the borrowed nixpkgs code segment from above
 in
@@ -32,7 +32,7 @@ in
     mutableExtensionsDir = false;
     package = (pkgs.vscode.override { isInsiders = true; }).overrideAttrs (oldAttrs: rec {
       pname = "vscode-insiders";
-      version = "1.84.0-${commit}";
+      version = "1.87.0-${commit}";
       src = (builtins.fetchurl {
         name = "${pname}-${version}.${archive_fmt}";
         url = "https://code.visualstudio.com/sha/download?build=insider&os=${plat}";

--- a/config/home-manager/programs/vscode/extensions
+++ b/config/home-manager/programs/vscode/extensions
@@ -35,6 +35,7 @@ mattn.Lisp
 mesonbuild.mesonbuild
 ms-azuretools.vscode-docker
 ms-dotnettools.csharp
+ms-dotnettools.vscode-dotnet-runtime
 ms-python.python
 ms-toolsai.jupyter
 ms-toolsai.jupyter-renderers
@@ -52,6 +53,7 @@ scala-lang.scala
 Shopify.ruby-lsp
 spacethimble.vscode-purescript-emmet
 streetsidesoftware.code-spell-checker
+svelte.svelte-vscode
 tamasfe.even-better-toml
 timonwong.shellcheck
 twxs.cmake

--- a/config/home-manager/programs/vscode/settings.nix
+++ b/config/home-manager/programs/vscode/settings.nix
@@ -88,5 +88,13 @@
       "editor.formatOnSave" = true;
       "editor.formatOnSaveMode" = "file";
     };
+    "[dockerfile]" = {
+      "editor.defaultFormatter" = "ms-azuretools.vscode-docker";
+    };
+    "[typescript]" = {
+      "editor.defaultFormatter" = "esbenp.prettier-vscode";
+    };
+    "rubyLsp.rubyVersionManager" = "none";
+    "rubyLsp.rubyExecutablePath" = "${pkgs.ruby_3_3}/bin/ruby";
   };
 }


### PR DESCRIPTION
- Update VS Code Insiders version from 1.84.0 to 1.87.0
- Add some extensions
- Add settings for some extensions