### PR TITLE
Fix the broken icon on the polybar

### DIFF
--- a/config/polybar/config.ini
+++ b/config/polybar/config.ini
@@ -57,7 +57,7 @@ pin-workspaces = false
 enable-click = true
 enable-scroll = false
 format = <label-monitor> <label-state>
-label-monitor = :%name%
+label-monitor = 󰍺:%name%
 label-monitor-foreground=${colors.nord4}
 label-monitor-underline=${colors.nord15}
 label-monitor-margin-left=2
@@ -79,12 +79,12 @@ label-empty-underline = ${colors.nord15}
 label-empty-padding = 1
 
 [module/date]
-type=internal/date
-interval=1
-label=%time%
-label-padding=1
-label-underline=${colors.nord9}
-time= %a %d %b %Y %T
+type = internal/date
+interval = 1
+label = %time%
+label-padding = 1
+label-underline = ${colors.nord9}
+time= 󰃰 %a %d %b %Y %T
 
 [module/volume]
 type = internal/pulseaudio


### PR DESCRIPTION
- Replace the icon removed from `Nerd Fonts`
- Unified white-space rule