### PR TITLE
Update home.stateVersion from 23.11 to 24.05

### DIFF
--- a/config/home-manager/home.nix
+++ b/config/home-manager/home.nix
@@ -21,7 +21,7 @@ in
   home = {
     username = builtins.getEnv "USER";
     homeDirectory = builtins.getEnv "HOME";
-    stateVersion = "23.11";
+    stateVersion = "24.05";
   };
 
   imports = synthetic;

--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -11,10 +11,10 @@ in
       # Nix related
       any-nix-shell
       cachix
-      rnix-lsp
+      nixd
       nix-prefetch-git
       nixpkgs-fmt
-      nixfmt
+      nixfmt-classic
       dep2nix
 
       # Utility

--- a/config/home-manager/home/packages/linux-desktop.nix
+++ b/config/home-manager/home/packages/linux-desktop.nix
@@ -31,7 +31,7 @@
       system-config-printer
       gnome.simple-scan
       microsoft-edge-dev
-      peazip
+      #peazip
       pdfarranger
       gimp
 

--- a/config/home-manager/services/gpg-agent.nix
+++ b/config/home-manager/services/gpg-agent.nix
@@ -5,6 +5,6 @@
     {
       enable = true;
       enableScDaemon = true;
-      pinentryFlavor = if pkgs.stdenv.isDarwin then "qt" else "gnome3";
+      pinentryPackage = if pkgs.stdenv.isDarwin then pkgs.pinentry-qt else pkgs.pinentry-gnome3;
     };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702685174,
-        "narHash": "sha256-HEXsloubVg26Y4COKvzg+JYfA2l0yg94eXYNr7UUe60=",
+        "lastModified": 1718596175,
+        "narHash": "sha256-0V5cmi5yGAae+eERohL4QfslyAOALuEzTHDU6ZgMUs8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0f10e1681d87c273a5c4a6d1b51d0b419c363793",
+        "rev": "8ffc704d8c23837502a63f58bd686caed3df5502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Modify some Nix packages
- Change the pinentry package specification attribute for `service.gpg-agent`
- Update the nix flake
- Comment out peazip due to build failure