### PR TITLE
Fix the Steam client flickering that occurred in xmonad

### DIFF
--- a/config/home-manager/home.nix
+++ b/config/home-manager/home.nix
@@ -24,6 +24,8 @@ in
     stateVersion = "24.05";
   };
 
+  nixpkgs.overlays = [ (import ./overlays/xmonad.nix) ];
+
   imports = synthetic;
 
   xresources.properties = {

--- a/config/home-manager/overlays/xmonad.nix
+++ b/config/home-manager/overlays/xmonad.nix
@@ -1,0 +1,44 @@
+self: super:
+{
+  haskellPackages = super.haskellPackages.override (old: {
+    overrides = self.lib.composeExtensions (old.overrides or (_: _: { }))
+      (
+        hself: hsuper: {
+          xmonad = super.haskell.lib.doJailbreak (hsuper.xmonad.overrideAttrs (oldAttrs: rec{
+            version = "v0.18.0";
+            sha256 = "sha256-bM2pHSelf0hVhKbYwYatnAo92NNsh9rl6ywrWSwwjEo=";
+            src = super.fetchFromGitHub
+              {
+                owner = "xmonad";
+                repo = "xmonad";
+                rev = version;
+                inherit sha256;
+              };
+          }));
+          xmonad-contrib = hsuper.xmonad-contrib.overrideAttrs (oldAttrs: rec{
+            version = "ec5c751b35c1c9b07bd4361617f7c4076aeaa85f";
+            sha256 = "sha256-S9IivsvYeWD/AtAgKUHH0amVfug0qOAPXjNvXbafXag=";
+            src = super.fetchFromGitHub
+              {
+                owner = "xmonad";
+                repo = "xmonad-contrib";
+                rev = version;
+                inherit sha256;
+              };
+          });
+          xmonad-extras = hsuper.xmonad-extras.overrideAttrs (oldAttrs: rec{
+            version = "14e1c4ce9759b959c05b03aac1bb718abc50f762";
+            sha256 = "sha256-9J6hfsAU8oH4l5mJ/W1p57yTxnLUh0dPkv6CXh3X9EA=";
+            src = super.fetchFromGitHub
+              {
+                owner = "xmonad";
+                repo = "xmonad-extras";
+                rev = version;
+                inherit sha256;
+              };
+          });
+        }
+      );
+  }
+  );
+}

--- a/config/home-manager/xsession.nix
+++ b/config/home-manager/xsession.nix
@@ -4,11 +4,10 @@
     windowManager = {
       xmonad = {
         enable = true;
-        extraPackages = haskellPackages: [
-          haskellPackages.dbus
-          haskellPackages.xmonad-contrib
-          haskellPackages.xmonad-extras
-          haskellPackages.xmonad
+        extraPackages = haskellPackages: with haskellPackages; [
+          dbus
+          xmonad-contrib
+          xmonad-extras
         ];
         enableContribAndExtras = true;
         config = ../../xmonad/xmonad.hs;

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
           xorg.libXext
           xorg.libXrandr
           xorg.libXScrnSaver
+          alsa-lib
         ];
         haskellPackages = with pkgs.haskellPackages; [
           haskell-language-server

--- a/xmonad/cabal.project
+++ b/xmonad/cabal.project
@@ -1,0 +1,16 @@
+packages: .
+
+source-repository-package
+  type: git
+  location: https://github.com/xmonad/xmonad
+  tag: v0.18.0
+
+source-repository-package
+  type: git
+  location: https://github.com/xmonad/xmonad-contrib
+  tag: ec5c751b35c1c9b07bd4361617f7c4076aeaa85f
+
+source-repository-package
+  type: git
+  location: https://github.com/xmonad/xmonad-extras
+  tag: 14e1c4ce9759b959c05b03aac1bb718abc50f762

--- a/xmonad/myxmonad.cabal
+++ b/xmonad/myxmonad.cabal
@@ -18,6 +18,7 @@ executable myxmonad
     , X11
     , xmonad
     , xmonad-contrib
+    , xmonad-extras
 
   default-language: Haskell2010
   ghc-options:      -Wall -fno-warn-missing-signatures

--- a/xmonad/xmonad.hs
+++ b/xmonad/xmonad.hs
@@ -78,6 +78,7 @@ import XMonad.Layout.PerWorkspace (onWorkspace)
 import XMonad.Layout.Spacing (spacing)
 import XMonad.Layout.Spiral (spiral)
 import XMonad.Layout.ThreeColumns (ThreeCol (ThreeColMid))
+import XMonad.Util.Hacks (fixSteamFlicker)
 import XMonad.Util.NamedActions
   ( NamedAction,
     addDescrKeys,
@@ -361,7 +362,7 @@ myConfig =
           <+> manageDocks
           <+> myManageHook
           <+> myManageHook',
-      handleEventHook = minimizeEventHook,
+      handleEventHook = fixSteamFlicker <+> minimizeEventHook,
       startupHook = myStartupHook,
       focusFollowsMouse = False,
       clickJustFocuses = False,


### PR DESCRIPTION
Modify the configuration to retrieve the relevant packages from GitHub. This change allows us to use the `fixSteamFlicker` function recently added to xmonad-contrib.