### PR TITLE
Update homen.stateVersion from 24.05 to 24.11

### DIFF
--- a/config/home-manager/home.nix
+++ b/config/home-manager/home.nix
@@ -21,7 +21,7 @@ in
   home = {
     username = builtins.getEnv "USER";
     homeDirectory = builtins.getEnv "HOME";
-    stateVersion = "24.05";
+    stateVersion = "24.11";
   };
 
   nixpkgs = {

--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -22,7 +22,6 @@ in
       nix-prefetch-git
       nixfmt-rfc-style
       nixd
-      dep2nix
 
       # Utility
       ghq

--- a/config/home-manager/home/packages/linux-desktop.nix
+++ b/config/home-manager/home/packages/linux-desktop.nix
@@ -23,12 +23,12 @@
       apache-directory-studio
       blueman
       system-config-printer
-      gnome.simple-scan
-      microsoft-edge-dev
+      simple-scan
+      microsoft-edge
       unstable.peazip
       pdfarranger
       gimp
-      gnome.gnome-control-center
+      gnome-control-center
 
       # Utility
       trash-cli

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723460660,
-        "narHash": "sha256-SmMk099DCZZF1fNgH7da2hEkI7NabXnXfdoPP3GfKGQ=",
+        "lastModified": 1733052534,
+        "narHash": "sha256-fqmu39j1Y0FEhF/KZcGUW9MjAGotAaTfN2gyb1a2LZ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2e2a2c9bc4a6684227207f67c551927f9d37df0",
+        "rev": "10f06c512e429ffd497761a5a49e31ada70e85ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Fix the renamed package name
- Remove `dep2nix`
  - `dep2nix` was removed from nixpkgs following the deprecation of `buildGoPackage`
- Replace removed package `microsoft-edge-dev` with `microsoft-edge`
- Update the nix flake