### PR TITLE
Update release channel to 25.05

### DIFF
--- a/config/home-manager/home.nix
+++ b/config/home-manager/home.nix
@@ -21,7 +21,7 @@ in
   home = {
     username = builtins.getEnv "USER";
     homeDirectory = builtins.getEnv "HOME";
-    stateVersion = "24.11";
+    stateVersion = "25.05";
   };
 
   nixpkgs = {

--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -90,7 +90,7 @@ in
         ruby_3_3
         rubocop
         python3
-        nodejs-18_x
+        nodejs_22
         jdk
         sbcl
         maxima

--- a/config/home-manager/home/packages/linux-desktop.nix
+++ b/config/home-manager/home/packages/linux-desktop.nix
@@ -7,16 +7,16 @@
       polybarFull
       feh
       pavucontrol
-      planify
+      #planify
       ledger-live-desktop
-      yubikey-manager-qt
+      yubioath-flutter
       remmina
       libreoffice
       google-chrome
       firefox
       keybase
       keybase-gui
-      partition-manager
+      gparted
       robo3t
       _1password-gui
       spotify
@@ -24,7 +24,6 @@
       blueman
       system-config-printer
       simple-scan
-      microsoft-edge
       unstable.peazip
       pdfarranger
       gimp
@@ -42,7 +41,6 @@
 
       # Drivers
       google-drive-ocamlfuse
-      xboxdrv
 
       # Experimental
       (callPackage ./cursor.nix { })

--- a/config/home-manager/programs/vscode/default.nix
+++ b/config/home-manager/programs/vscode/default.nix
@@ -80,6 +80,8 @@ in
         ln -rs "$unpacked" "$packed"
       '';
     });
-    extensions = pkgs.vscode-utils.extensionsFromVscodeMarketplace extensions;
-  } // settings;
+    profiles.default = {
+      extensions = pkgs.vscode-utils.extensionsFromVscodeMarketplace extensions;
+    } // settings;
+  };
 }

--- a/config/home-manager/services/gpg-agent.nix
+++ b/config/home-manager/services/gpg-agent.nix
@@ -1,10 +1,9 @@
 { pkgs, ... }:
 
 {
-  services.gpg-agent =
-    {
-      enable = true;
-      enableScDaemon = true;
-      pinentryPackage = if pkgs.stdenv.isDarwin then pkgs.pinentry-qt else pkgs.pinentry-gnome3;
-    };
+  services.gpg-agent = {
+    enable = true;
+    enableScDaemon = true;
+    pinentry.package = if pkgs.stdenv.isDarwin then pkgs.pinentry-qt else pkgs.pinentry-gnome3;
+  };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747095323,
-        "narHash": "sha256-F+GlgJmmqZygMf81npvrZlS+02ThJ5DV9b3v3N8d0IE=",
+        "lastModified": 1748214964,
+        "narHash": "sha256-fp4wY2W+ugcGHPYgplLR+luu4t7PxsxlU43dyzJmgv4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "740ccecccb097c71993a3ad1090c9151272b3c7d",
+        "rev": "ed8c8414faebbeb25681ab93ab881f06f2e20440",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
             ghcid
             cabal-install
             ormolu
-            (haskell-language-server.override { supportedGhcVersions = [ "966" ]; })
+            (haskell-language-server.override { supportedGhcVersions = [ "984" ]; })
             ruff
           ]
           ++ lib.optionals stdenv.isLinux [ alsa-lib ];


### PR DESCRIPTION
- Replace renamed packages:
  - `yubikey-manager-qt` -> `yubioath-flutter`
  - `partition-manager` -> `gparted`
- Remove unused package: `microsoft-edge`
- Temporarily disable `planify` by commenting it out
- Update flake inputs with `nix flake update`