### PR TITLE
chore: Ignore non-essential Markdown files globally

### DIFF
--- a/config/home-manager/programs/git.nix
+++ b/config/home-manager/programs/git.nix
@@ -64,7 +64,20 @@ let
     # Windows shortcuts
     "*.lnk"
   ];
-
+  Claude = [
+    ".claude/"
+  ];
+  Markdown = [
+    # Markdown files
+    "*.md"
+    "*.markdown"
+    "*.mkd"
+    "*.mdown"
+    "*.mdwn"
+    "*.mdtxt"
+    "*.mdtext"
+    "!README.md"
+  ];
 in
 {
   programs.git = {
@@ -87,16 +100,32 @@ in
     extraConfig = {
       core = {
         editor = "emacs";
-        excludesfile = "~/.gitignore";
       };
-      credential = { helper = "netrc -f ~/.netrc.gpg -v"; };
-      color = { ui = true; };
-      init = { defaultBranch = "main"; };
-      ghq = { root = [ "~/Go/src" "~/Codex" ]; };
+      credential = {
+        helper = "netrc -f ~/.netrc.gpg -v";
+      };
+      color = {
+        ui = true;
+      };
+      init = {
+        defaultBranch = "main";
+      };
+      ghq = {
+        root = [
+          "~/Go/src"
+          "~/Codex"
+        ];
+      };
       pull = {
         rebase = true;
       };
     };
-    ignores = builtins.concatLists [ Linux macOS Windows ];
+    ignores = builtins.concatLists [
+      Linux
+      macOS
+      Windows
+      Claude
+      Markdown
+    ];
   };
 }


### PR DESCRIPTION
Add a global .gitignore rule to exclude all Markdown (`.md*`) files from being tracked by default.

This prevents personal notes, drafts, and other non-project Markdown files from accidentally being committed to any repository.

Crucially, `README.md` is explicitly un-ignored (`!README.md`) so it can still be tracked as an essential project file.