### PR TITLE
ci: update GitHub Actions schedules to run daily

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -2,8 +2,8 @@ name: Update flake.lock
 
 on:
   schedule:
-    # Run every Monday at 00:00 UTC
-    - cron: 0 0 * * 1
+    # Run daily at 00:00 UTC
+    - cron: 0 0 * * *
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-vscode-extensions.yml
+++ b/.github/workflows/update-vscode-extensions.yml
@@ -2,8 +2,8 @@ name: Update VSCode Extensions
 
 on:
   schedule:
-    # Run monthly on the 1st at 02:00 UTC
-    - cron: 0 2 1 * *
+    # Run daily at 02:00 UTC
+    - cron: 0 2 * * *
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- Change flake update from weekly to daily (00:00 UTC)
- Change VS Code extensions update from monthly to daily (02:00 UTC)