### PR TITLE
fix(packages): explicitly manage gnupg in home-manager

### DIFF
--- a/config/home-manager/home/packages/darwin.nix
+++ b/config/home-manager/home/packages/darwin.nix
@@ -6,7 +6,6 @@
       fish
       bash # The version of bash preinstalled on macos is old
       pinentry_mac
-      gnupg
       iterm2
       sequelpro
     ];

--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -32,6 +32,7 @@
         httpie
         curlie
         mutagen
+        gnupg
         yubikey-manager
         yubikey-personalization
         rlwrap


### PR DESCRIPTION
- Add gnupg to common packages to ensure availability
- Move gnupg from darwin-specific to shared configuration
- Keep pinentry_mac in darwin-specific packages

Due to package configuration changes, the gnupg binary was no longer being installed implicitly. This change ensures gnupg is explicitly managed by home-manager and available on all platforms.