### PR TITLE
refactor(packages): remove 1password from home-manager configuration

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -45,7 +45,6 @@
         unstable.goreleaser
         rclone
         ripgrep
-        _1password-cli
 
         # DevOps
         docker-compose

--- a/config/home-manager/home/packages/linux-desktop.nix
+++ b/config/home-manager/home/packages/linux-desktop.nix
@@ -18,7 +18,6 @@
       keybase-gui
       gparted
       robo3t
-      _1password-gui
       spotify
       apache-directory-studio
       blueman


### PR DESCRIPTION
- Remove _1password-cli from default packages
- Remove _1password-gui from linux-desktop packages

These packages have been moved to system-level configuration (configuration.nix) to ensure proper polkit integration and system-wide availability.