### PR TITLE
fix(vscode): format extensions.nix output to pass CI checks

### DIFF
--- a/config/home-manager/programs/vscode/extensions.nix
+++ b/config/home-manager/programs/vscode/extensions.nix
@@ -4,91 +4,91 @@
     publisher = "aaron-bond";
     version = "3.0.2";
     sha256 = "15w1ixvp6vn9ng6mmcmv9ch0ngx8m85i1yabxdfn6zx3ypq802c5";
-    
+
   }
   {
     name = "cucumberautocomplete";
     publisher = "alexkrechik";
     version = "3.0.5";
     sha256 = "1x51ya0k9ybc01dzzamlp22x1f0a6m1jby2q5986500mxbi9s2jf";
-    
+
   }
   {
     name = "Bookmarks";
     publisher = "alefragnani";
     version = "13.5.0";
     sha256 = "06pmlmd3wahplhv5r8jdk19xlv2rmhiggmmw6s30pnys2bj5va50";
-    
+
   }
   {
     name = "claude-code";
     publisher = "anthropic";
     version = "1.0.65";
     sha256 = "0b3m3wrmbbjx3p51d410wvaxccl244x5vgpl7z9rirv8zzp9d2iy";
-    
+
   }
   {
     name = "vscode-cabal-fmt";
     publisher = "berberman";
     version = "0.0.3";
     sha256 = "0kfcipzhmf70447vmdikipq5s8192hm055is8hfxp4k3v32mz3ad";
-    
+
   }
   {
     name = "nord-visual-studio-code";
     publisher = "arcticicestudio";
     version = "0.19.0";
     sha256 = "05bmzrmkw9syv2wxqlfddc3phjads6ql2grknws85fcqzqbfl1kb";
-    
+
   }
   {
     name = "markdown-mermaid";
     publisher = "bierner";
     version = "1.28.0";
     sha256 = "0vc94jhx77yzixry5lw29sc8idhnf5rl1d7k0gkmswxm6bl0611l";
-    
+
   }
   {
     name = "vscode-fish";
     publisher = "bmalehorn";
     version = "1.0.39";
     sha256 = "023iaw66fxsz77yw166rfyy5rd9khzx9nxghvsm79n2hpghh772g";
-    
+
   }
   {
     name = "vscode-tailwindcss";
     publisher = "bradlc";
     version = "0.14.25";
     sha256 = "0aanllx1fnjbd5wvaqx857xx2y32104czbfyi41nvs586i83nw1m";
-    
+
   }
   {
     name = "cucumber-official";
     publisher = "CucumberOpen";
     version = "1.11.0";
     sha256 = "1dyk89b3rb795wvqs08hxgg469aa50dqgjgglrbpn24rm6nvvypr";
-    
+
   }
   {
     name = "path-intellisense";
     publisher = "christian-kohler";
     version = "2.10.0";
     sha256 = "06x9ksl4bghfpxh4n65d1d7dr11spl140p9ch4mc01nrdibgckbc";
-    
+
   }
   {
     name = "vscode-eslint";
     publisher = "dbaeumer";
     version = "3.0.15";
     sha256 = "10ng8kbydm1dzz2ififww343b68i718ari8dpzrfs73b40s9vsx1";
-    
+
   }
   {
     name = "vscode-markdownlint";
     publisher = "DavidAnson";
     version = "0.60.0";
     sha256 = "18fw4snqfa7bys04r8748vv6x7gfaq2bqvhqm9x3z1fsf7mimv06";
-    
+
   }
   {
     name = "ruff";
@@ -102,112 +102,112 @@
     publisher = "dhall";
     version = "0.0.4";
     sha256 = "1zin7s827bpf9yvzpxpr5n6mv0b5rhh3civsqzmj52mdq365d2js";
-    
+
   }
   {
     name = "dhall-lang";
     publisher = "dhall";
     version = "0.0.4";
     sha256 = "0sa04srhqmngmw71slnrapi2xay0arj42j4gkan8i11n7bfi1xpf";
-    
+
   }
   {
     name = "gitlens";
     publisher = "eamodio";
     version = "2025.7.3105";
     sha256 = "004fskdgynmi8dj47kjc7bzwf6z2q260k61vlvn2gv0jx054ss5v";
-    
+
   }
   {
     name = "EditorConfig";
     publisher = "EditorConfig";
     version = "0.17.4";
     sha256 = "1hxzvrj65dnzhjk6qp7dy860gvl8n57wb8s8s6chdil04a2xi0ri";
-    
+
   }
   {
     name = "prettier-vscode";
     publisher = "esbenp";
     version = "11.0.0";
     sha256 = "1fcz8f4jgnf24kblf8m8nwgzd5pxs2gmrv235cpdgmqz38kf9n54";
-    
+
   }
   {
     name = "vscode-reveal";
     publisher = "evilz";
     version = "4.3.3";
     sha256 = "06hl6d8s896nx5z6a62xw2wwip1v4ir2ianybxlplz6c825x1ara";
-    
+
   }
   {
     name = "figma-vscode-extension";
     publisher = "figma";
     version = "0.4.1";
     sha256 = "10h2mmmb39mbj0gxx2hss4ciyp9x2hhmpsi8v3w3alka2agqp2nr";
-    
+
   }
   {
     name = "shell-format";
     publisher = "foxundermoon";
     version = "7.2.8";
     sha256 = "1fkpj78xp40jaa2xh4yw87xl7ww73fg27zbxdq81j2wg793ycyv7";
-    
+
   }
   {
     name = "copilot";
     publisher = "GitHub";
     version = "1.351.1711";
     sha256 = "0gk1qbn63jbdrar56vmqhmcyq06fmycxpxm1s1pnqy5pd98g04pn";
-    
+
   }
   {
     name = "copilot-chat";
     publisher = "GitHub";
     version = "0.30.2025073102";
     sha256 = "11w3i1wbg12jv1qfbb718g2bik25fw80mmbdrh45ibpsha4r3pp0";
-    
+
   }
   {
     name = "Go";
     publisher = "golang";
     version = "0.49.0";
     sha256 = "0chwsaasw445pn6qf6786al3snn4l39mpb5iyzyrxlxgvm6s3mph";
-    
+
   }
   {
     name = "geminicodeassist";
     publisher = "Google";
     version = "2.43.0";
     sha256 = "1yqjmflbiv8lvlyqzzybzs65li0n5hjmpx37wwvr3i8blgvypscd";
-    
+
   }
   {
     name = "vscode-graphql";
     publisher = "GraphQL";
     version = "0.13.2";
     sha256 = "1aqsash65s2xkqhnm6s6mxq7ahw179376lv420wsn4yri0hs4vpl";
-    
+
   }
   {
     name = "vscode-graphql-syntax";
     publisher = "GraphQL";
     version = "1.3.8";
     sha256 = "0dgd6d1a5hv61zf2ak66ic49vhnmyabkshv4njzv6ws6gy8pck6p";
-    
+
   }
   {
     name = "todo-tree";
     publisher = "Gruntfuggly";
     version = "0.0.226";
     sha256 = "0yrc9qbdk7zznd823bqs1g6n2i5xrda0f9a7349kknj9wp1mqgqn";
-    
+
   }
   {
     name = "HCL";
     publisher = "HashiCorp";
     version = "0.6.0";
     sha256 = "1bab360z7mhijjmnxx1prqv9n3kf5m8qakpibysgqiq7pc78xbb5";
-    
+
   }
   {
     name = "terraform";
@@ -221,105 +221,105 @@
     publisher = "haskell";
     version = "2.6.0";
     sha256 = "0bgqkgc0c88g9wj68n9kzyq8qpfaf12l55hcgwd0lh3y4vpwcnys";
-    
+
   }
   {
     name = "vscode-test-explorer";
     publisher = "hbenl";
     version = "2.22.1";
     sha256 = "1hvzrv7vaxn993imb8h40hch0svg9vrmj7a01pmqwp4hjdkbzxgs";
-    
+
   }
   {
     name = "latex-workshop";
     publisher = "James-Yu";
     version = "10.10.0";
     sha256 = "0q8ddqp6p2j9bq7df28b0i3nhr58ww7q4iml7ky3gnk7prx6h5yx";
-    
+
   }
   {
     name = "Sbt";
     publisher = "itryapitsin";
     version = "0.1.7";
     sha256 = "107xd3l8qr6b9cfdjhk084a10b7nq3sjq4mmfkapmckvynyw419w";
-    
+
   }
   {
     name = "vscode-edit-csv";
     publisher = "janisdd";
     version = "0.11.5";
     sha256 = "1mg9nyhxdy5bw9w0mzxcl806hyw90f55vij5yggvfx4wbzhfjcyh";
-    
+
   }
   {
     name = "language-haskell";
     publisher = "justusadam";
     version = "3.6.0";
     sha256 = "115y86w6n2bi33g1xh6ipz92jz5797d3d00mr4k8dv5fz76d35dd";
-    
+
   }
   {
     name = "vscode-colorize";
     publisher = "kamikillerto";
     version = "0.17.1";
     sha256 = "0svjkhg3n3b3imz6ipky79l2drn0nfzk5sh7jyjflj0rda7hja17";
-    
+
   }
   {
     name = "git-worktree-manager";
     publisher = "jackiotyu";
     version = "3.6.0";
     sha256 = "00dq3w25fy02msx8xakx56d8yg091ns53yjm56alflm74dh9cb3g";
-    
+
   }
   {
     name = "vscode-clangd";
     publisher = "llvm-vs-code-extensions";
     version = "0.2.0";
     sha256 = "09az6vx3z4yhcf3ygcl1cxyflngc7ig2wcyjncs93dnaw2xjz5r3";
-    
+
   }
   {
     name = "i18n-ally";
     publisher = "Lokalise";
     version = "2.13.1";
     sha256 = "15zpfd6sh38hv87yzabkiswmmw94vh6w6ypldrm70ckbq61v3dj2";
-    
+
   }
   {
     name = "Kotlin";
     publisher = "mathiasfrohlich";
     version = "1.7.1";
     sha256 = "0zi8s1y9l7sfgxfl26vqqqylsdsvn5v2xb3x8pcc4q0xlxgjbq1j";
-    
+
   }
   {
     name = "Lisp";
     publisher = "mattn";
     version = "0.1.12";
     sha256 = "0k10d77ffl6ybmk7mrpmlsawzwppp87aix2a2i24jq7lqnnqb9n7";
-    
+
   }
   {
     name = "mesonbuild";
     publisher = "mesonbuild";
     version = "1.27.0";
     sha256 = "0p0addwf4lqnhkd39k8wj5cj2c1ps3naqrjg2dc481n3qz1w6h3l";
-    
+
   }
   {
     name = "dotenv";
     publisher = "mikestead";
     version = "1.0.1";
     sha256 = "0rs57csczwx6wrs99c442qpf6vllv2fby37f3a9rhwc8sg6849vn";
-    
+
   }
   {
     name = "vscode-docker";
     publisher = "ms-azuretools";
     version = "2.0.0";
     sha256 = "0sjnbzark9vqbzzg1z2zh9zr2prqd5xa2fdkhdsjz73x99xaq733";
-    
+
   }
   {
     name = "python";
@@ -340,112 +340,112 @@
     publisher = "ms-toolsai";
     version = "1.3.2025062701";
     sha256 = "036yc8570k2xp5agrvhlz4w43h862l0jb3fdnz77z1v6imqf79fg";
-    
+
   }
   {
     name = "remote-ssh";
     publisher = "ms-vscode-remote";
     version = "0.121.2025073115";
     sha256 = "0n8in0qiicnjxvp95gdk0f3syx3bpydcl7spzjy78wqyqk68f3kc";
-    
+
   }
   {
     name = "cmake-tools";
     publisher = "ms-vscode";
     version = "1.22.2";
     sha256 = "1cv5gpbw2av1ca4dj22skiymkpbgvdsjvbj9pd7q1fyi3g801sil";
-    
+
   }
   {
     name = "remote-ssh-edit";
     publisher = "ms-vscode-remote";
     version = "0.87.0";
     sha256 = "1qqsnzn9z11jr72n7cl0ab6i9mv49c0ijcp699zbglv5092gmrf9";
-    
+
   }
   {
     name = "makefile-tools";
     publisher = "ms-vscode";
     version = "0.13.9";
     sha256 = "1wl0q6ph87di2cc87sv9d7xjk2ns24arcjik575igrhgax8fqf5m";
-    
+
   }
   {
     name = "remote-explorer";
     publisher = "ms-vscode";
     version = "0.6.2025072209";
     sha256 = "1f5qm8ql60ja5qn5s7mccdhanfvfkvs9zii6dc39fvka7nc3bsh9";
-    
+
   }
   {
     name = "test-adapter-converter";
     publisher = "ms-vscode";
     version = "0.2.1";
     sha256 = "0d823dh1594yf5vyfdpg68z5vjn6pa6pmnx6nph95daspzgsab43";
-    
+
   }
   {
     name = "remote-containers";
     publisher = "ms-vscode-remote";
     version = "0.424.0";
     sha256 = "04dc8vh00jbd6hlif30v513fk3bryxxcl92mjinanvcyaijz73h4";
-    
+
   }
   {
     name = "vscode-remote-extensionpack";
     publisher = "ms-vscode-remote";
     version = "0.26.0";
     sha256 = "0xjld7p1zg9zybcw47xzrikgyc3hp9lfk6vbrm0syba8n90k8jk1";
-    
+
   }
   {
     name = "liquidhaskell-diagnostics";
     publisher = "MustafaHafidi";
     version = "1.3.1";
     sha256 = "19hs9ld9mag45yz46r8hrx0hp2dc9392yzxv7z51k2zxl5x8d07k";
-    
+
   }
   {
     name = "rails-run-spec-vscode";
     publisher = "noku";
     version = "0.1.4";
     sha256 = "1i8digd3dxrcpjlkl86g3hfh47f19zm6ly3svxx54fil86661fcc";
-    
+
   }
   {
     name = "nix-ide";
     publisher = "jnoortheen";
     version = "0.4.22";
     sha256 = "1ib8czlqhqq1rz6jrazfd9z3gfqdwqazxdvwmsyp765m0vf78xcg";
-    
+
   }
   {
     name = "ide-purescript";
     publisher = "nwolverson";
     version = "0.26.6";
     sha256 = "0kxrk3fl8s6rc170iicamiwwsh03959jdk9x8a68nzigz1qc10nd";
-    
+
   }
   {
     name = "language-purescript";
     publisher = "nwolverson";
     version = "0.2.10";
     sha256 = "1d15p8vdfxb52jrp4fbs56b62by569dw0q6bx9gadi9fyk0sq4i4";
-    
+
   }
   {
     name = "vscode-pbkit";
     publisher = "pbkit";
     version = "0.0.8";
     sha256 = "08k74nlaim2s41b93rhms220bwnax5m305gdcicppbkxphlb5kn4";
-    
+
   }
   {
     name = "material-icon-theme";
     publisher = "PKief";
     version = "5.24.0";
     sha256 = "1mrn37h41c8kwkhxdns2dx8fw0x7cjq8skpaal5nfqz0pn4kwisa";
-    
+
   }
   {
     name = "rust-analyzer";
@@ -466,70 +466,70 @@
     publisher = "saoudrizwan";
     version = "3.20.3";
     sha256 = "1s7cdl5wipdwvyi4rd7mkcpyrihlslmnbkwhk06fjjx7lp00ar03";
-    
+
   }
   {
     name = "scala";
     publisher = "scala-lang";
     version = "0.5.9";
     sha256 = "05wy2gfz7msfwzy295d9hs1bzgqqz5054kwiwyx5kv6g14msl06f";
-    
+
   }
   {
     name = "ruby-lsp";
     publisher = "Shopify";
     version = "0.9.31";
     sha256 = "0144f6xhxads0gj9m8vsapl56a369h3fijbvrpaxa46908dg95d6";
-    
+
   }
   {
     name = "slim";
     publisher = "sianglim";
     version = "0.1.2";
     sha256 = "0k63dh7j6k5ci9y3wy4nyawr2l5rszw7lwqngayn0nkwxpdjd23x";
-    
+
   }
   {
     name = "vscode-purescript-emmet";
     publisher = "spacethimble";
     version = "1.0.0";
     sha256 = "1lg6sabdh7p5hqvmaq1pq4fb7n15bz4n7idrqdfrw0f9l90sl9hh";
-    
+
   }
   {
     name = "code-spell-checker";
     publisher = "streetsidesoftware";
     version = "4.2.3";
     sha256 = "0qcxgyw704b4rr5igrq86pm8xdaz880gspv98q3rj2i57hqzpx3z";
-    
+
   }
   {
     name = "vscode-styled-components";
     publisher = "styled-components";
     version = "1.7.8";
     sha256 = "1k4ymnq91758qpazip78g6lv2m2a1mxc2iz0fzqk92q02y6c10jn";
-    
+
   }
   {
     name = "vscode-stylelint";
     publisher = "stylelint";
     version = "1.5.3";
     sha256 = "1krm508kgrd6aghn5giim35rgf25qfd5z292jb1131hqz3vjq0vy";
-    
+
   }
   {
     name = "svelte-vscode";
     publisher = "svelte";
     version = "109.10.0";
     sha256 = "1aa8ph02n6k8qh39n7b59p6qv8fg5v0wbdb11pdbfcx891zxr726";
-    
+
   }
   {
     name = "even-better-toml";
     publisher = "tamasfe";
     version = "0.21.2";
     sha256 = "0208cms054yj2l8pz9jrv3ydydmb47wr4i0sw8qywpi8yimddf11";
-    
+
   }
   {
     name = "shellcheck";
@@ -543,62 +543,62 @@
     publisher = "tuttieee";
     version = "0.85.1";
     sha256 = "132i9xsqmjmb6fxqlx49k4va5m3rdxz6al4qpq76zjm3p3zdiqsh";
-    
+
   }
   {
     name = "cmake";
     publisher = "twxs";
     version = "0.0.17";
     sha256 = "11hzjd0gxkq37689rrr2aszxng5l9fwpgs9nnglq3zhfa1msyn08";
-    
+
   }
   {
     name = "errorlens";
     publisher = "usernamehw";
     version = "3.26.0";
     sha256 = "0rmvzr5qsbq8zni9vwg4y6bh8l6s5hci974x676m57hi0pfj82d4";
-    
+
   }
   {
     name = "vscode-gradle";
     publisher = "vscjava";
     version = "3.17.2025062603";
     sha256 = "16scvnhwbg0wwbxhbq91n4ik7qf6isw2w55j60ffngfxvnvy8fzm";
-    
+
   }
   {
     name = "vscode-java-debug";
     publisher = "vscjava";
     version = "0.58.2025063005";
     sha256 = "0anbxj1j27m93lm4c6lars63ap8snnq2k9zjc8q87vr8rd3dnv94";
-    
+
   }
   {
     name = "code-d";
     publisher = "webfreak";
     version = "0.23.2";
     sha256 = "0l8a9qjbhk9s09hb0ajm6p4v19ry4r2h53w5gij49xh4i29xrw5z";
-    
+
   }
   {
     name = "change-case";
     publisher = "wmaurer";
     version = "1.0.0";
     sha256 = "0dxsdahyivx1ghxs6l9b93filfm8vl5q2sa4g21fiklgdnaf7pxl";
-    
+
   }
   {
     name = "Idris";
     publisher = "zjhmale";
     version = "0.9.8";
     sha256 = "1dfh1rgybhnf5driwgxh69a1inyzxl72njhq93qq7mhacwnyfsdp";
-    
+
   }
   {
     name = "vscode-proto3";
     publisher = "zxh404";
     version = "0.5.5";
     sha256 = "08gjq2ww7pjr3ck9pyp5kdr0q6hxxjy3gg87aklplbc9bkfb0vqj";
-    
+
   }
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,9 +41,12 @@ Updates VSCode extensions Nix expressions from the marketplace.
 - Reads extension list from file or installed VSCode
 - Queries VS Code marketplace for latest versions in parallel
 - Generates `extensions.nix` with metadata and SHA256 hashes
+- **Automatically formats output with nixfmt-rfc-style** (requires Nix)
 - Automatic retry with exponential backoff for failed requests
 - Configurable parallelism to avoid overwhelming the marketplace API
-- Run automatically monthly via GitHub Actions
+- Run automatically daily via GitHub Actions
+
+**Note:** This script requires Nix to be installed for formatting the generated file.
 
 ### Workflow
 


### PR DESCRIPTION
- Add nixfmt-rfc-style formatting step after generating extensions.nix
- Use 'nix fmt' to ensure consistent formatting with project settings
- Update README to document Nix requirement for formatting
- Maintain consistent execution approach for both local and CI environments

This fixes CI failures where the generated extensions.nix file doesn't meet the formatting requirements of the Check Formatting job.