### PR TITLE
feat(vscode): restore window zoom level setting

### DIFF
--- a/config/home-manager/programs/vscode/settings.nix
+++ b/config/home-manager/programs/vscode/settings.nix
@@ -37,6 +37,7 @@
         "git-rebase-todo" = "default";
       };
     };
+    "window.zoomLevel" = -1.0;
     "terminal" = {
       "integrated" = {
         "defaultProfile" = {


### PR DESCRIPTION
- Add back window.zoomLevel = -1.0 setting
- This setting provides better readability on high DPI displays
- Realized it was useful after trying without it