### PR TITLE
feat(packages): add tree command for directory visualization

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -47,6 +47,7 @@
         ripgrep
         tlaplus
         tlaps
+        tree
 
         # DevOps
         docker-compose


### PR DESCRIPTION
Add tree to default.nix to provide directory structure visualization in the command line. Tree supports both Linux and macOS platforms.