### PR TITLE
feat(pre-commit): improve shellcheck configuration and resolve warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -209,11 +209,21 @@
                   always_run = true;
                 };
 
-                # Shell script linting
+                # Shell script linting (general)
                 shellcheck = {
                   enable = true;
-                  # SC1091 is about following sourced files, which exist at runtime
-                  entry = "${pkgs.shellcheck}/bin/shellcheck -e SC1091";
+                  excludes = [ "^\\.envrc$" ]; # Handle .envrc separately
+                  entry = "${pkgs.shellcheck}/bin/shellcheck -x";
+                };
+
+                # Shell script linting for .envrc specifically
+                shellcheck-envrc = {
+                  enable = true;
+                  name = "shellcheck-envrc";
+                  entry = "${pkgs.shellcheck}/bin/shellcheck -e SC2148";
+                  files = "^\\.envrc$";
+                  language = "system";
+                  pass_filenames = true;
                 };
 
                 # Fish shell syntax check

--- a/function/add_nix_channels.sh
+++ b/function/add_nix_channels.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=function/error.sh
 source "$(dirname "${BASH_SOURCE[0]}")/error.sh"
 
 #######################################

--- a/function/install/fisher.sh
+++ b/function/install/fisher.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=function/error.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../error.sh"
 
 #######################################

--- a/function/install/home_manager.sh
+++ b/function/install/home_manager.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=function/error.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../error.sh"
 
 #######################################

--- a/function/install/homebrew.sh
+++ b/function/install/homebrew.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=function/error.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../error.sh"
 
 #######################################

--- a/function/install/nix.sh
+++ b/function/install/nix.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=function/error.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../error.sh"
 
 #######################################
@@ -13,6 +14,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/../error.sh"
 load_profile() {
   if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
     set +u
+    # shellcheck source=/dev/null
     source '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
     set -u
   fi

--- a/function/install/xcode_command_line_tools.sh
+++ b/function/install/xcode_command_line_tools.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=function/error.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../error.sh"
 
 #######################################

--- a/setup.sh
+++ b/setup.sh
@@ -19,11 +19,17 @@ abs_path="$(
 readonly abs_path
 
 # Import functions
+# shellcheck source=./function/install/xcode_command_line_tools.sh
 source ./function/install/xcode_command_line_tools.sh
+# shellcheck source=./function/install/homebrew.sh
 source ./function/install/homebrew.sh
+# shellcheck source=./function/install/nix.sh
 source ./function/install/nix.sh
+# shellcheck source=./function/install/home_manager.sh
 source ./function/install/home_manager.sh
+# shellcheck source=./function/install/fisher.sh
 source ./function/install/fisher.sh
+# shellcheck source=./function/add_nix_channels.sh
 source ./function/add_nix_channels.sh
 
 #######################################


### PR DESCRIPTION
- Enable shellcheck -x flag to follow source paths during analysis
- Add 'shellcheck source=' directives to all shell scripts for proper file resolution
- Create separate shellcheck hook for .envrc with SC2148 exclusion
- Use repository-relative paths in directives for consistent resolution
- Keep /dev/null directive for external system files (nix-daemon.sh)

This comprehensive shellcheck configuration ensures:
- All shell scripts get proper static analysis with source file tracking
- .envrc (direnv config) is handled appropriately without shebang warnings
- SC1091 warnings are resolved through proper source directives
- Full visibility of potential issues in shell scripts is maintained