### PR TITLE
fix(vscode): remove deprecated terminal.integrated.enableBell setting

### DIFF
--- a/config/home-manager/programs/vscode/settings.nix
+++ b/config/home-manager/programs/vscode/settings.nix
@@ -5,7 +5,6 @@
     "accessibility.signals.terminalBell" = {
       "sound" = "on";
     };
-    "terminal.integrated.enableBell" = true;
     "editor" = {
       "emptySelectionClipboard" = true;
       "fontFamily" = "'Fira Code', 'FiraCode Nerd Font', Menlo, Monaco, 'Courier New', monospace";


### PR DESCRIPTION
The terminal.integrated.enableBell setting was deprecated on October 13, 2024. It has been replaced by:
- accessibility.signals.terminalBell (for sound)
- terminal.integrated.enableVisualBell (for visual bell)

This change prevents VS Code from automatically opening settings.json due to the deprecated setting.

The accessibility.signals.terminalBell was already configured, so terminal bell functionality is maintained.