### PR TITLE
feat(vscode): add SSH remote platform configurations

### DIFF
--- a/config/home-manager/programs/vscode/settings.nix
+++ b/config/home-manager/programs/vscode/settings.nix
@@ -72,7 +72,9 @@
         "useLocalServer" = false;
         "remotePlatform" = {
           eto = "linux";
+          "eto.stultitia.me" = "linux";
           heilwig = "macOS";
+          chroe = "macOS";
         };
       };
     };


### PR DESCRIPTION
- Add eto.stultitia.me as Linux platform for internet-based SSH connection
- Add chroe as macOS platform
- Keep existing eto (Linux) and heilwig (macOS) configurations

This allows VS Code to properly detect the platform when connecting to these remote hosts via SSH.