### PR TITLE
fix(gemini-cli): update to v0.1.21 using prebuilt binary

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -75,25 +75,7 @@
           }
         ))
         (callPackage ./codex.nix { inherit pkgs unstable; })
-        (unstable.gemini-cli.overrideAttrs (
-          finalAttrs: oldAttrs: {
-            version = "0.1.21"; # gemini-cli version
-            src = pkgs.fetchFromGitHub {
-              owner = "google-gemini";
-              repo = "gemini-cli";
-              tag = "v${finalAttrs.version}";
-              hash = "sha256-4s+mU8BhJQDwLJtKcWTH0ks/W4n/FuEjWzT8aFQAPWI=";
-              postFetch = ''
-                ${lib.getExe pkgs.npm-lockfile-fix} $out/package-lock.json
-              '';
-            };
-
-            npmDeps = pkgs.fetchNpmDeps {
-              inherit (finalAttrs) src;
-              hash = "sha256-yt1Z/atE07vt27OdiLHPV1ZSHJ80zkGkcuro7rJxOrc="; # gemini-cli npmDeps
-            };
-          }
-        ))
+        (callPackage ./gemini-cli.nix { inherit pkgs; })
         claudius
 
         # Development toolchain

--- a/config/home-manager/home/packages/gemini-cli.nix
+++ b/config/home-manager/home/packages/gemini-cli.nix
@@ -1,49 +1,36 @@
-{
-  lib,
-  buildNpmPackage,
-  fetchFromGitHub,
-  nodejs_22,
-}:
+{ pkgs, lib, ... }:
 
-buildNpmPackage rec {
+pkgs.stdenv.mkDerivation rec {
   pname = "gemini-cli";
-  version = "0.1.1";
+  version = "0.1.21";
 
-  src = fetchFromGitHub {
-    owner = "google-gemini";
-    repo = "gemini-cli";
-    rev = "52afcb3a1233237b07aa86b1678f4c4eded70800";
-    hash = "sha256-KNnfo5hntQjvc377A39+QBemeJjMVDRnNuGY/93n3zc=";
+  src = pkgs.fetchurl {
+    url = "https://github.com/google-gemini/gemini-cli/releases/download/v${version}/gemini.js";
+    hash = "sha256-PimVERqbuCDdP6EsFKGGXmlQEtSEdZtU8Qdo1hPwc5E=";
   };
 
-  npmDepsHash = "sha256-/IAEcbER5cr6/9BFZYuV2j1jgA75eeFxaLXdh1T3bMA";
+  dontUnpack = true;
 
-  nodejs = nodejs_22;
-
-  npmBuildScript = "bundle";
-
-  postPatch = ''
-    substituteInPlace scripts/generate-git-commit-info.js \
-      --replace-fail "import { execSync } from 'child_process';" \
-      "const execSync = (cmd) => cmd.includes(\"rev-parse\") ? \"${builtins.substring 0 7 src.rev}\" : \"\";"
-  '';
+  nativeBuildInputs = [ pkgs.makeWrapper ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/node_modules/@google/gemini-cli
-    cp -r bundle package.json LICENSE README.md $out/lib/node_modules/@google/gemini-cli/
+    mkdir -p $out/lib
+    cp $src $out/lib/gemini.js
+    chmod +x $out/lib/gemini.js
 
     mkdir -p $out/bin
-    ln -s $out/lib/node_modules/@google/gemini-cli/bundle/gemini.js $out/bin/gemini
+    makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/gemini \
+      --add-flags "$out/lib/gemini.js"
 
     runHook postInstall
   '';
 
-  meta = {
-    description = "An open-source AI agent that brings the power of Gemini directly into your terminal.";
+  meta = with lib; {
+    description = "An open-source AI agent that brings the power of Gemini directly into your terminal";
     homepage = "https://github.com/google-gemini/gemini-cli";
-    license = lib.licenses.asl20;
+    license = licenses.asl20;
     mainProgram = "gemini";
   };
 }


### PR DESCRIPTION
Use GitHub release binary instead of building from source to avoid npm dependency issues. Node.js 22.17.0 resolves punycode deprecation warnings.