### PR TITLE
feat(rust): introduce fenix for newer Rust toolchain and update codex

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -1,18 +1,33 @@
 { pkgs, unstable, ... }:
 
-unstable.rustPlatform.buildRustPackage rec {
+let
+  # Use fenix to get a newer Rust version
+  fenix = import (fetchTarball "https://github.com/nix-community/fenix/archive/main.tar.gz") {
+    inherit (pkgs) system;
+  };
+
+  # Get Rust nightly which should have all the required features stabilized
+  rustToolchain = fenix.latest;
+
+  # Create custom rustPlatform with newer Rust
+  customRustPlatform = pkgs.makeRustPlatform {
+    inherit (rustToolchain) cargo rustc;
+  };
+in
+# Use custom Rust platform with newer compiler
+customRustPlatform.buildRustPackage rec {
   pname = "codex-cli";
-  version = "rust-v0.22.0";
+  version = "rust-v0.23.0";
 
   src = pkgs.fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     rev = "${version}";
-    hash = "sha256-JTwtydW8LLBH/55+8a/BbqlZtkXsFKbT8dGoDEAjk1c=";
+    hash = "sha256-JS2nRh3/MNQ0mfdr2/Q10sAB38yWBLpw2zFf0dJORuM=";
   };
 
   sourceRoot = "source/codex-rs";
-  cargoHash = "sha256-3PljlyPfDsnjGmR/0iM7Fu1TnyDj31pKVcOU/izsL30=";
+  cargoHash = "sha256-HbhOiTO7qFp64v+Bb62V1LxPH7qeTnWwkJKPEN4Vx6c=";
 
   nativeBuildInputs = with unstable; [ pkg-config ];
   buildInputs = with unstable; [ openssl ];


### PR DESCRIPTION
- Add fenix to get latest Rust nightly toolchain
- Update codex-cli: rust-v0.22.0 → rust-v0.23.0
- This enables building codex v0.23.0 which requires newer Rust features