### PR TITLE
fix: make codex-cli build on macOS by conditionally using autoPatchel…

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -29,14 +29,22 @@ customRustPlatform.buildRustPackage rec {
   sourceRoot = "source/codex-rs";
   cargoHash = "sha256-qJn2oN/9LVLhHnaNp+x9cUEMODrGrgV3SiR0ykIx7B4=";
 
-  nativeBuildInputs = with unstable; [
-    pkg-config
-    autoPatchelfHook
-  ];
-  buildInputs = with unstable; [
-    openssl
-    stdenv.cc.cc.lib # for libgcc_s.so.1
-  ];
+  nativeBuildInputs =
+    with unstable;
+    [
+      pkg-config
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      autoPatchelfHook
+    ];
+  buildInputs =
+    with unstable;
+    [
+      openssl
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      stdenv.cc.cc.lib # for libgcc_s.so.1
+    ];
 
   doCheck = false;
 


### PR DESCRIPTION
…fHook

- autoPatchelfHook is Linux-specific for patching ELF binaries
- macOS uses Mach-O format, not ELF, so the hook causes build failures
- Apply autoPatchelfHook and libgcc_s.so.1 only on Linux systems