### PR TITLE
fix: improve codex-cli update script to correctly 
  calculate cargoHash

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -27,7 +27,7 @@ customRustPlatform.buildRustPackage rec {
   };
 
   sourceRoot = "source/codex-rs";
-  cargoHash = "sha256-qJn2oN/9LVLhHnaNp+x9cUEMODrGrgV3SiR0ykIx7B4=";
+  cargoHash = "sha256-OMGGgg6hYdZ40vcUxVsWyLentFBj62CYEH3NJ909kYM=";
 
   nativeBuildInputs =
     with unstable;


### PR DESCRIPTION
## Summary
  Fix codex-cli build failures on both macOS and Linux due to incorrect cargoHash

  ## Problem
  - cargoHash was not updated when codex-cli was bumped to v0.34.0 in PR #297
  - Update script failed to calculate correct cargoHash due to configuration 
  mismatch
  - Build fails with: \`specified: 
  sha256-qJn2oN/9LVLhHnaNp+x9cUEMODrGrgV3SiR0ykIx7B4= got: 
  sha256-OMGGgg6hYdZ40vcUxVsWyLentFBj62CYEH3NJ909kYM=\`

  ## Solution
  - Update cargoHash to correct value for v0.34.0
  - Improve update script to match actual build configuration:
    - Use unstable packages (matching codex.nix configuration)
    - Add platform-specific dependencies (autoPatchelfHook for Linux only)
    - Add --impure flag for fenix fetching

  ## Test Plan
  - [x] Test \`home-manager switch --flake .#aarch64-darwin --impure\` on macOS
  - [x] Test \`home-manager switch --flake .#x86_64-linux --impure\` on Linux
  - [ ] Verify update script correctly calculates cargoHash for future updates