### PR TITLE
feat(xsession): switch SSH agent from gnome-keyring to 1Password

### DIFF
--- a/config/home-manager/xsession.nix
+++ b/config/home-manager/xsession.nix
@@ -15,8 +15,11 @@
       };
     };
     initExtra = ''
-      eval $(gnome-keyring-daemon --start --components=pkcs11,secrets,ssh)
-      export SSH_AUTH_SOCK
+      # Start gnome-keyring without SSH component (SSH is handled by 1Password)
+      eval $(gnome-keyring-daemon --start --components=pkcs11,secrets)
+
+      # Use 1Password SSH agent
+      export SSH_AUTH_SOCK="$HOME/.1password/agent.sock"
 
       export XMODIFIERS="@im=fcitx"
       export GTK_IM_MODULE="fcitx"


### PR DESCRIPTION
- Remove SSH component from gnome-keyring-daemon startup
- Configure SSH_AUTH_SOCK to use 1Password agent socket
- Keeps pkcs11 and secrets components of gnome-keyring active