### PR TITLE
feat(packages): add scrcpy for Android device control

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -45,6 +45,7 @@
         unstable.goreleaser
         rclone
         ripgrep
+        scrcpy
         tlaplus
         tlaps
         tree


### PR DESCRIPTION
Add scrcpy utility for displaying and controlling Android devices over USB or TCP/IP. Supported on both Linux and macOS platforms.