### PR TITLE
feat(packages): import Azure packages configuration

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -1,6 +1,10 @@
 { pkgs, lib, ... }:
 
 {
+  imports = [
+    ./azure.nix
+  ];
+
   home = {
     packages = lib.flatten (
       with pkgs;


### PR DESCRIPTION
Import azure.nix from default.nix to include Azure CLI tools for all platforms. This maintains the hierarchical design while adding azure-cli, azure-storage-azcopy, and aks-preview extension.