### PR TITLE
feat(claude-code): upgrade to 2.0.8 and enhance update script

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -72,12 +72,13 @@
 
         # AI Tools
         (unstable.claude-code.overrideAttrs (
-          _finalAttrs: _oldAttrs: rec {
-            version = "2.0.5";
+          _finalAttrs: oldAttrs: rec {
+            version = "2.0.8";
             src = fetchzip {
               url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-              hash = "sha256-ZAolpT/NW48NpIoY2jUzbBlcHmyNcw+G1GhZ40qtJoY=";
+              hash = "sha256-WxXkUZs/sQp7PJfSPCv8EwbvUGYgePhouKv/YFzOd14=";
             };
+            npmDepsHash = "sha256-5AFExga9P8G1J2gTSmXL1UqetRlmNedcWQ8DoFWji8E=";
           }
         ))
         (callPackage ./codex.nix { inherit pkgs unstable; })

--- a/scripts/update-claude-code.py
+++ b/scripts/update-claude-code.py
@@ -20,8 +20,9 @@ import update_lib as lib
 CONFIG = lib.UpdateConfig(
     tool_name="claude-code",
     nix_file=Path("config/home-manager/home/packages/default.nix"),
-    version_pattern=r'(unstable\.claude-code\.overrideAttrs\s*\(\s*_finalAttrs:\s*_oldAttrs:\s*rec\s*\{\s*version\s*=\s*")([^"]+)(")',
+    version_pattern=r'(unstable\.claude-code\.overrideAttrs\s*\(\s*_finalAttrs:\s*oldAttrs:\s*rec\s*\{\s*version\s*=\s*")([^"]+)(")',
     hash_pattern=r'(unstable\.claude-code\.overrideAttrs.*?hash\s*=\s*")([^"]+)(")',
+    npm_hash_pattern=r'(unstable\.claude-code\.overrideAttrs.*?npmDepsHash\s*=\s*")([^"]+)(")',
 )
 
 PACKAGE_NAME = "@anthropic-ai/claude-code"


### PR DESCRIPTION
- Update claude-code from 2.0.5 to 2.0.8
- Add npmDepsHash calculation to update script using prefetch-npm-deps
- Fix pattern matching in update-claude-code.py (oldAttrs vs _oldAttrs)
- Implement proper npm dependencies hash calculation via tarball extraction
- Replace complex build-based hash detection with direct prefetch-npm-deps usage

The update script now:
1. Downloads the npm package tarball
2. Extracts and generates package-lock.json if missing
3. Uses prefetch-npm-deps to calculate the correct npmDepsHash
4. Updates both src hash and npmDepsHash in the nix file

This ensures claude-code builds correctly with proper npm dependencies.