### PR TITLE
fix(ai-tools): resolve build errors and simplify package definitions

### DIFF
--- a/config/home-manager/home/packages/claude-code.nix
+++ b/config/home-manager/home/packages/claude-code.nix
@@ -1,0 +1,43 @@
+{ pkgs, ... }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "claude-code";
+  version = "2.0.8";
+
+  src = pkgs.fetchzip {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
+    hash = "sha256-WxXkUZs/sQp7PJfSPCv8EwbvUGYgePhouKv/YFzOd14=";
+  };
+
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/@anthropic-ai/claude-code
+    cp -r . $out/lib/node_modules/@anthropic-ai/claude-code
+
+    mkdir -p $out/bin
+    makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/claude \
+      --add-flags "$out/lib/node_modules/@anthropic-ai/claude-code/cli.js" \
+      --set CLAUDE_NO_AUTO_UPDATE 1
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export HOME=$(mktemp -d)
+    $out/bin/claude --version | grep -q "${version}"
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Use Claude, Anthropic's AI assistant, right from your terminal";
+    homepage = "https://github.com/anthropics/claude-code";
+    license = licenses.unfree;
+    maintainers = [ ];
+    mainProgram = "claude";
+  };
+}

--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -1,21 +1,6 @@
 { pkgs, unstable, ... }:
 
-let
-  # Use fenix to get a newer Rust version with file_lock stabilized
-  fenix = import (fetchTarball "https://github.com/nix-community/fenix/archive/main.tar.gz") {
-    inherit (pkgs) system;
-  };
-
-  # Get nightly Rust which has unstable features including file_lock
-  # file_lock is still unstable as of Rust 1.82 - see https://github.com/rust-lang/rust/issues/130994
-  rustToolchain = fenix.latest;
-
-  # Create custom rustPlatform with newer Rust
-  customRustPlatform = unstable.makeRustPlatform {
-    inherit (rustToolchain) cargo rustc;
-  };
-in
-customRustPlatform.buildRustPackage rec {
+unstable.rustPlatform.buildRustPackage rec {
   pname = "codex-cli";
   version = "rust-v0.44.0";
 
@@ -29,8 +14,7 @@ customRustPlatform.buildRustPackage rec {
   sourceRoot = "source/codex-rs";
   cargoHash = "sha256-sR7Y1SfP0akLRRvP/6tu3gZRNvQbG/a+4bOSEbbrV30=";
 
-  # Set nightly Rust channel for unstable features
-  CARGO_BUILD_RUSTC = "${rustToolchain.rustc}/bin/rustc";
+  # Enable unstable features (file_lock)
   RUSTC_BOOTSTRAP = "1";
 
   nativeBuildInputs =

--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -71,18 +71,9 @@
         redis
 
         # AI Tools
-        (unstable.claude-code.overrideAttrs (
-          _finalAttrs: oldAttrs: rec {
-            version = "2.0.8";
-            src = fetchzip {
-              url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-              hash = "sha256-WxXkUZs/sQp7PJfSPCv8EwbvUGYgePhouKv/YFzOd14=";
-            };
-            npmDepsHash = "sha256-5AFExga9P8G1J2gTSmXL1UqetRlmNedcWQ8DoFWji8E=";
-          }
-        ))
-        (callPackage ./codex.nix { inherit pkgs unstable; })
-        (callPackage ./gemini-cli.nix { inherit pkgs; })
+        (callPackage ./claude-code.nix { })
+        (callPackage ./codex.nix { })
+        (callPackage ./gemini-cli.nix { })
         claudius
 
         # Development toolchain

--- a/scripts/update-claude-code.py
+++ b/scripts/update-claude-code.py
@@ -19,10 +19,9 @@ import update_lib as lib
 # Configuration
 CONFIG = lib.UpdateConfig(
     tool_name="claude-code",
-    nix_file=Path("config/home-manager/home/packages/default.nix"),
-    version_pattern=r'(unstable\.claude-code\.overrideAttrs\s*\(\s*_finalAttrs:\s*oldAttrs:\s*rec\s*\{\s*version\s*=\s*")([^"]+)(")',
-    hash_pattern=r'(unstable\.claude-code\.overrideAttrs.*?hash\s*=\s*")([^"]+)(")',
-    npm_hash_pattern=r'(unstable\.claude-code\.overrideAttrs.*?npmDepsHash\s*=\s*")([^"]+)(")',
+    nix_file=Path("config/home-manager/home/packages/claude-code.nix"),
+    version_pattern=r'(\s+version\s*=\s*")([^"]+)(")',
+    hash_pattern=r'(\s+hash\s*=\s*")([^"]+)(")',
 )
 
 PACKAGE_NAME = "@anthropic-ai/claude-code"


### PR DESCRIPTION
- Change claude-code from buildNpmPackage to stdenv.mkDerivation
  - Avoids npmDepsHash issues (package only has optionalDependencies)
  - Add HOME env var in installCheckPhase to prevent EACCES errors
  - Remove npm_hash_pattern from update-claude-code.py

- Simplify codex.nix build
  - Remove fenix and custom rustPlatform
  - Use RUSTC_BOOTSTRAP=1 for unstable features instead

- Fix callPackage usage in default.nix
  - Remove explicit package arguments
  - Let Nix auto-resolve from overlays (pkgs, unstable)

This fixes AI-tools build failures and simplifies maintenance.