### PR TITLE
fix(codex): disable strip on darwin

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -235,6 +235,10 @@ rustPlatform.buildRustPackage (
 
     doCheck = false;
 
+    # Keep Darwin builds unstripped. A full Home Manager switch on macOS produced
+    # unusable Codex binaries during fixup, while Linux benefits from normal strip.
+    dontStrip = pkgs.stdenv.isDarwin;
+
     meta = with pkgs.lib; {
       description = "Lightweight coding agent that runs in your terminal";
       homepage = "https://github.com/openai/codex";


### PR DESCRIPTION
## Summary
- disable stripping for the custom Codex package on Darwin only
- keep Linux builds using the default strip behavior
- document this as a macOS-specific workaround observed during Home Manager switch builds

## Why
- the original uncommitted fix used `dontStrip = true`, which was broader than necessary
- limiting the workaround to Darwin avoids inflating Linux outputs unnecessarily
- other custom macOS binaries in this repo were checked, and no additional strip workaround was justified

## Validation
- built `config/home-manager/home/packages/codex.nix` successfully on macOS
- confirmed the resulting `codex`, `codex-exec`, and `codex-tui` binaries run
- audited other custom packaged macOS binaries and did not find another package that currently needs the same workaround
