### PR TITLE
fix(darwin): disable direnv checks

### DIFF
--- a/config/home-manager/overlays/darwin-workarounds.nix
+++ b/config/home-manager/overlays/darwin-workarounds.nix
@@ -9,6 +9,7 @@
 # - nix 2.28.5: nix-shell test failure (blocks cachix)
 # - setproctitle 1.3.7: fork test segfault (blocks azure-cli, glances)
 # - pre-commit: test-only dotnet dependency triggers LLVM build
+# - direnv 2.37.1: fish test is killed on macOS (blocks direnv-elvish-hook)
 # - inetutils 2.7: clang format string error on macOS (blocks home-manager)
 #
 # Note: tlaps is excluded on macOS via lib.optionals in default.nix
@@ -24,6 +25,11 @@ if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
       postCheck = "";
       pytestFlags = [ ];
       disabledTests = [ ];
+    });
+    direnvNoCheck = prev.direnv.overrideAttrs (_old: {
+      doCheck = false;
+      nativeCheckInputs = [ ];
+      checkPhase = "";
     });
   in
   {
@@ -43,6 +49,9 @@ if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
 
     # pre-commit's test-only dotnet dependency is unnecessary for use here.
     pre-commit = preCommitNoCheck;
+
+    # direnv's fish tests are flaky on macOS and block elvish hook generation.
+    direnv = direnvNoCheck;
   }
 else
   { }


### PR DESCRIPTION
## Summary
- disable `direnv` checks on `aarch64-darwin`
- keep the existing Darwin workaround scope limited to Apple Silicon macOS
- document the `direnv 2.37.1` fish test failure in the overlay comments

## Why
- `origin/main` reproducibly fails to build `direnv` on macOS during `test-fish`
- that failure blocks the generated `direnv-elvish-hook` and breaks Home Manager activation
- the check phase is not needed for consuming the packaged binary in this repo

## Validation
- reproduced the failure from a clean `origin/main` worktree: `make test-fish` ends with `Killed: 9`
- applied the workaround in an isolated branch
- confirmed the `direnv-elvish-hook` build succeeds with the workaround
