### PR TITLE
fix(ai-tools): stabilize automated updates

### DIFF
--- a/.github/workflows/update-ai-tools.yml
+++ b/.github/workflows/update-ai-tools.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           ./scripts/update-ai-tools-all.sh
 
+      - name: Build AI tools
+        run: |
+          ./scripts/build-ai-tools.sh
+
       - name: Check for changes
         id: changes
         run: |
@@ -101,6 +105,10 @@ jobs:
           CODEX_FORCE_CARGO_HASH: "1"
         run: |
           python3 scripts/update-codex-cli.py
+
+      - name: Build AI tools
+        run: |
+          ./scripts/build-ai-tools.sh
 
       - name: Check for changes
         id: changes

--- a/config/home-manager/home/packages/claude-code.nix
+++ b/config/home-manager/home/packages/claude-code.nix
@@ -2,11 +2,11 @@
 
 pkgs.stdenv.mkDerivation rec {
   pname = "claude-code";
-  version = "2.1.91";
+  version = "2.1.96";
 
   src = pkgs.fetchzip {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-    hash = "sha256-u7jdM6hTYN05ZLPz630Yj7gI0PeCSArg4O6ItQRAMy4=";
+    hash = "sha256-9umpTBjvKllbr8gFDNfjy9KQCz4113xuiQw/CnAs9c0=";
   };
 
   nativeBuildInputs = [ pkgs.makeWrapper ];

--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -111,10 +111,10 @@ let
   # cargo vendor utility. codex-utils-cargo-bin is only used by test helpers,
   # and tests are disabled for this package, so the stub is sufficient.
   cargoHashes = {
-    x86_64-linux = "sha256-F53k63oSpXoC2FHiEjbBRbtaMzNH82xpU/g86ZfoWuo=";
-    aarch64-linux = "sha256-F53k63oSpXoC2FHiEjbBRbtaMzNH82xpU/g86ZfoWuo=";
-    x86_64-darwin = "sha256-F53k63oSpXoC2FHiEjbBRbtaMzNH82xpU/g86ZfoWuo=";
-    aarch64-darwin = "sha256-F53k63oSpXoC2FHiEjbBRbtaMzNH82xpU/g86ZfoWuo=";
+    x86_64-linux = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
+    aarch64-linux = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
+    x86_64-darwin = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
+    aarch64-darwin = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
   };
 
   rustyV8Version = "146.4.0";
@@ -143,13 +143,13 @@ in
 rustPlatform.buildRustPackage (
   rec {
     pname = "codex-cli";
-    version = "rust-v0.117.0";
+    version = "rust-v0.118.0";
 
     src = pkgs.fetchFromGitHub {
       owner = "openai";
       repo = "codex";
       rev = "${version}";
-      hash = "sha256-Ezd8KaEMVeJPKC74CSPhecPLZghm0v6JkQTCPhr/2nY=";
+      hash = "sha256-FdtV+CIqTInnegcXrXBxw4aE0JnNDh4GdYKwUDjSk9Y=";
     };
 
     sourceRoot = "source/codex-rs";
@@ -162,8 +162,12 @@ rustPlatform.buildRustPackage (
 
     postPatch = ''
       mapfile -t vendored_v8_dirs < <(
-        find "$cargoDepsCopy" -maxdepth 1 -mindepth 1 -type d \
-          \( -name 'v8' -o -name 'v8-*' \) | sort
+        while IFS= read -r cargo_toml; do
+          dirname "$cargo_toml"
+        done < <(
+          find "$cargoDepsCopy" -type f -name Cargo.toml \
+            -path '*/v8*/Cargo.toml' -print
+        ) | sort -u
       )
 
       if [ "''${#vendored_v8_dirs[@]}" -ne 1 ]; then

--- a/config/home-manager/home/packages/droid.nix
+++ b/config/home-manager/home/packages/droid.nix
@@ -2,17 +2,17 @@
 
 let
   pname = "droid";
-  version = "0.90.0";
+  version = "0.96.1";
 
   # Platform-specific source URLs and hashes
   sources = {
     aarch64-darwin = {
       url = "https://downloads.factory.ai/factory-cli/releases/${version}/darwin/arm64/droid";
-      hash = "sha256-+IOmEw9oy76O0g/EFdhmhxhirVkOgJtEOdl0t3LR06A=";
+      hash = "sha256-ES/3kWdh0kieo8eKElezs5OE9UoCtMs05z1GH+NIYDA=";
     };
     x86_64-linux = {
       url = "https://downloads.factory.ai/factory-cli/releases/${version}/linux/x64/droid";
-      hash = "sha256-1sVKOoXQh/1Wd5Pog+Mi0DCn/hh+p3Xv1bUaSrKTQKI=";
+      hash = "sha256-bD4oNu8/dU7zdyb5V62NX9ipM/PEOCuU712p4qdvtls=";
     };
   };
 

--- a/config/home-manager/home/packages/gemini-cli.nix
+++ b/config/home-manager/home/packages/gemini-cli.nix
@@ -1,30 +1,58 @@
 { pkgs, lib, ... }:
 
-pkgs.stdenv.mkDerivation rec {
+let
   pname = "gemini-cli";
-  version = "0.35.3";
+  version = "0.36.0";
+  assetName = "gemini-cli-bundle.zip";
+  isArchive = lib.hasSuffix ".zip" assetName;
+in
+pkgs.stdenv.mkDerivation rec {
+  inherit pname version;
 
-  src = pkgs.fetchurl {
-    url = "https://github.com/google-gemini/gemini-cli/releases/download/v${version}/gemini.js";
-    hash = "sha256-I94yM/wkzCCnJhshvc2CUN00xIXJcSKUjK/EWDAbNR8=";
-  };
+  src = (if isArchive then pkgs.fetchzip else pkgs.fetchurl) (
+    {
+      url = "https://github.com/google-gemini/gemini-cli/releases/download/v${version}/${assetName}";
+      hash = "sha256-wu+QZ5roBNY1mwtte+7opKFBRdOCXONW95UEJ7M3gJI=";
+    }
+    // lib.optionalAttrs isArchive {
+      stripRoot = false;
+    }
+  );
 
-  dontUnpack = true;
+  dontUnpack = !isArchive;
+  dontBuild = true;
 
   nativeBuildInputs = [ pkgs.makeWrapper ];
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib
-    cp $src $out/lib/gemini.js
-    chmod +x $out/lib/gemini.js
+    mkdir -p $out/lib/gemini-cli
+  ''
+  + (
+    if isArchive then
+      ''
+        cp -r . $out/lib/gemini-cli
+      ''
+    else
+      ''
+        cp $src $out/lib/gemini-cli/gemini.js
+      ''
+  )
+  + ''
+    chmod +x $out/lib/gemini-cli/gemini.js
 
     mkdir -p $out/bin
     makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/gemini \
-      --add-flags "$out/lib/gemini.js"
+      --add-flags "$out/lib/gemini-cli/gemini.js"
 
     runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    export HOME=$(mktemp -d)
+    $out/bin/gemini --version | grep -q "${version}"
   '';
 
   meta = with lib; {

--- a/config/home-manager/home/packages/rusty-v8-prebuilt-out-dir.patch
+++ b/config/home-manager/home/packages/rusty-v8-prebuilt-out-dir.patch
@@ -1,5 +1,27 @@
+# What: make `rusty_v8` accept Bazel-provided archives and bindings for the
+# windows-gnullvm experiment.
+# Scope: `rusty_v8` build.rs only; no V8 source or Bazel rule changes.
+
 --- a/build.rs
 +++ b/build.rs
+@@ -543,10 +543,15 @@
+ }
+ 
+ fn static_lib_name(suffix: &str) -> String {
+-  let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+-  if target_os == "windows" {
++  let target = env::var("TARGET").unwrap();
++  let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
++  if target.contains("windows-gnullvm") {
++    // rustc looks for GNU-style archive names when bundling `-lstatic` on the
++    // gnullvm targets, even though the prebuilt release is a COFF `.lib`.
++    format!("librusty_v8{suffix}.a")
++  } else if target_os == "windows" {
+     format!("rusty_v8{suffix}.lib")
+   } else {
+     format!("librusty_v8{suffix}.a")
+   }
+ }
 @@ -577,7 +577,23 @@
    path
  }

--- a/config/home-manager/home/packages/stub-runfiles.patch
+++ b/config/home-manager/home/packages/stub-runfiles.patch
@@ -1,7 +1,7 @@
 diff -urN orig/Cargo.lock mod/Cargo.lock
 --- orig/Cargo.lock
 +++ mod/Cargo.lock
-@@ -8330,7 +8330,6 @@
+@@ -8213,7 +8213,6 @@
  [[package]]
  name = "runfiles"
  version = "0.1.0"
@@ -12,7 +12,7 @@ diff -urN orig/Cargo.lock mod/Cargo.lock
 diff -urN orig/Cargo.toml mod/Cargo.toml
 --- orig/Cargo.toml
 +++ mod/Cargo.toml
-@@ -267,7 +267,7 @@
+@@ -263,7 +263,7 @@
  regex-lite = "0.1.8"
  reqwest = "0.12"
  rmcp = { version = "0.15.0", default-features = false }

--- a/scripts/build-ai-tools.sh
+++ b/scripts/build-ai-tools.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+export NIXPKGS_ALLOW_UNFREE=1
+
+COMMON_NIX_EXPR='
+  let
+    flake = builtins.getFlake (toString ./.);
+    system = builtins.currentSystem;
+    pkgs = import flake.inputs.nixpkgs {
+      inherit system;
+      config.allowUnfree = true;
+      overlays = [
+        (_final: _prev: {
+          unstable = import flake.inputs.nixpkgs-unstable {
+            inherit system;
+            config.allowUnfree = true;
+          };
+        })
+      ];
+    };
+  in
+'
+
+build_package() {
+  local label="$1"
+  local relpath="$2"
+
+  echo "Building ${label}..."
+  nix build --impure --no-link --print-out-paths --expr \
+    "${COMMON_NIX_EXPR} pkgs.callPackage ${relpath} {}"
+}
+
+printf 'Verifying AI tool builds...\n\n'
+
+build_package "claude-code" ./config/home-manager/home/packages/claude-code.nix
+printf '\n'
+build_package "codex-cli" ./config/home-manager/home/packages/codex.nix
+printf '\n'
+build_package "droid" ./config/home-manager/home/packages/droid.nix
+printf '\n'
+build_package "gemini-cli" ./config/home-manager/home/packages/gemini-cli.nix
+printf '\n'
+
+echo "All AI tool builds succeeded."

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -266,6 +266,41 @@ def run_nix_prefetch(url: str, *, timeout: int = SUBPROCESS_TIMEOUT) -> str:
     return result.stdout.strip()
 
 
+def convert_nix_hash_to_sri(
+    hash_value: str,
+    *,
+    hash_algo: str = "sha256",
+    timeout: int = SUBPROCESS_TIMEOUT,
+) -> str:
+    """Convert a Nix hash to SRI format across old and new Nix CLIs."""
+    commands = [
+        ["nix", "hash", "to-sri", "--type", hash_algo, hash_value],
+        [
+            "nix",
+            "hash",
+            "convert",
+            "--hash-algo",
+            hash_algo,
+            "--to",
+            "sri",
+            hash_value,
+        ],
+    ]
+
+    last_exc: SubprocessError | None = None
+    for cmd in commands:
+        try:
+            result = run_command(cmd, timeout=timeout)
+            return result.stdout.strip()
+        except SubprocessError as exc:
+            last_exc = exc
+
+    if last_exc is None:
+        msg = "No nix hash conversion command was attempted"
+        raise RuntimeError(msg)
+    raise last_exc
+
+
 # ----- Retry Logic -----------------------------------------------------------------
 
 

--- a/scripts/update-ai-tools-all.sh
+++ b/scripts/update-ai-tools-all.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Update all AI tools
 
-set -e
+set -euo pipefail
 
 echo "Updating AI tools..."
 echo

--- a/scripts/update-codex-cli.py
+++ b/scripts/update-codex-cli.py
@@ -430,7 +430,7 @@ def _extract_cargo_hash(content: str, system: str) -> str | None:
     return _extract_cargo_hashes(content).get(system)
 
 
-def _update_cargo_hashes(content: str, new_hash: str) -> str:
+def _update_cargo_hashes(content: str, system: str, new_hash: str) -> str:
     match = re.search(
         r'cargoHashes\s*=\s*{\n(?P<body>.*?)};',
         content,
@@ -457,10 +457,24 @@ def _update_cargo_hashes(content: str, new_hash: str) -> str:
         block_indent = block_indent_match.group(1) if block_indent_match else ""
         entry_indent = f"{block_indent}  "
 
-    updated_body = "\n".join(
-        f'{entry_indent}{supported_system} = "{new_hash}";'
+    hashes = _extract_cargo_hashes(content)
+    hashes[system] = new_hash
+
+    ordered_systems = [
+        supported_system
         for supported_system in _SUPPORTED_SYSTEMS
-    )
+        if supported_system in hashes
+    ]
+    remaining_systems = [
+        supported_system
+        for supported_system in hashes
+        if supported_system not in _SUPPORTED_SYSTEMS
+    ]
+
+    updated_body = "\n".join(
+        f'{entry_indent}{supported_system} = "{hashes[supported_system]}";'
+        for supported_system in [*ordered_systems, *remaining_systems]
+    ) + "\n"
 
     return content[:match.start("body")] + updated_body + content[match.end("body"):]
 
@@ -500,21 +514,15 @@ def _needs_cargo_update(
 ) -> bool:
     hashes = _extract_cargo_hashes(content)
     existing = hashes.get(system)
-    has_placeholder = any(
-        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" in hash_value
-        for hash_value in hashes.values()
+    has_placeholder = (
+        existing is not None
+        and "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" in existing
     )
-    has_mismatch = len(set(hashes.values())) > 1
     return (
         force
         or version_updated
         or existing is None
         or has_placeholder
-        or has_mismatch
-        or any(
-            supported_system not in hashes
-            for supported_system in _SUPPORTED_SYSTEMS
-        )
     )
 
 
@@ -601,7 +609,11 @@ def main() -> int:
         version_updated=version_updated,
     ):
         new_cargo_hash = _calculate_cargo_hash(updated_content)
-        updated_content = _update_cargo_hashes(updated_content, str(new_cargo_hash))
+        updated_content = _update_cargo_hashes(
+            updated_content,
+            system,
+            str(new_cargo_hash),
+        )
 
     if updated_content != content:
         lib.write_file(NIX_FILE, updated_content)

--- a/scripts/update-cursor.py
+++ b/scripts/update-cursor.py
@@ -140,16 +140,9 @@ def _prefetch_sri_hash(url: str) -> str:
 
     # Convert to SRI format
     try:
-        result = common.run_command(
-            [
-                "nix", "hash", "convert",
-                "--hash-algo", "sha256", "--to", "sri", nix32_hash,
-            ],
-            check=True,
-        )
-        return result.stdout.strip()
+        return common.convert_nix_hash_to_sri(nix32_hash)
     except common.SubprocessError as e:
-        msg = "nix hash convert"
+        msg = "nix hash to-sri/convert"
         raise common.SubprocessError(msg, e.error) from e
 
 

--- a/scripts/update-droid.py
+++ b/scripts/update-droid.py
@@ -116,23 +116,10 @@ def _prefetch_hash_for(version: str, system: str) -> PlatformHash:
     url = _download_url(version, system)
 
     try:
-        # Get base32 hash from nix-prefetch-url
-        base32_hash = common.run_nix_prefetch(url)
-
-        # Convert to SRI format using nix hash convert
-        result = common.run_command([
-            "nix",
-            "hash",
-            "convert",
-            "--hash-algo",
-            "sha256",
-            "--to",
-            "sri",
-            base32_hash,
-        ])
-        sri_hash = result.stdout.strip()
-
-        return PlatformHash(system=system, hash=sri_hash)
+        return PlatformHash(
+            system=system,
+            hash=common.convert_nix_hash_to_sri(common.run_nix_prefetch(url)),
+        )
     except common.SubprocessError as exc:
         msg = f"Failed to prefetch hash for {system}"
         raise common.SubprocessError(msg, exc.error) from exc

--- a/scripts/update-gemini-cli.py
+++ b/scripts/update-gemini-cli.py
@@ -2,7 +2,7 @@
 """Update gemini-cli tool using functional programming style.
 
 This script automatically updates the gemini-cli package by fetching
-the latest prebuilt binary from GitHub releases.
+the latest supported release asset from GitHub releases.
 
 Usage:
     ./update-gemini-cli.py
@@ -14,6 +14,7 @@ Files modified:
 import sys
 from pathlib import Path
 
+import common
 import update_lib as lib
 
 # Configuration
@@ -25,36 +26,67 @@ CONFIG = lib.UpdateConfig(
 )
 
 GITHUB_REPO = "google-gemini/gemini-cli"
+GITHUB_API = "https://api.github.com"
+ASSET_NAME_PATTERN = r'(assetName\s*=\s*")([^"]+)(";)'
+PREFERRED_ASSETS = (
+    "gemini-cli-bundle.zip",
+    "gemini.js",
+)
+
+
+def _fetch_release_asset() -> tuple[lib.Version, str]:
+    """Fetch the latest release version and the supported asset name."""
+    response = common.fetch_json(
+        f"{GITHUB_API}/repos/{GITHUB_REPO}/releases/latest",
+    )
+    version = lib.Version(response["tag_name"].removeprefix("v"))
+    assets = {asset["name"] for asset in response.get("assets", [])}
+
+    for asset_name in PREFERRED_ASSETS:
+        if asset_name in assets:
+            return version, asset_name
+
+    msg = f"Could not find a supported asset in latest release: {sorted(assets)}"
+    raise ValueError(msg)
 
 
 def main() -> int:
     """Main entry point using functional pipeline."""
-    # Custom hash calculation for binary file
-    def calculate_binary_hash(version: lib.Version) -> lib.Hash:
-        url = f"https://github.com/{GITHUB_REPO}/releases/download/v{version}/gemini.js"
-        return lib.calculate_hash(url, unpack=False)
+    # Custom hash calculation for the published release asset
+    def calculate_binary_hash(version: lib.Version, asset_name: str) -> lib.Hash:
+        url = (
+            f"https://github.com/{GITHUB_REPO}/releases/download/v{version}/"
+            f"{asset_name}"
+        )
+        return lib.calculate_hash(url, unpack=asset_name.endswith(".zip"))
 
     # Use base GitHub pipeline with modifications
     def pipeline() -> lib.UpdateResult:
-        # Get latest version
-        latest_version = lib.fetch_github_release(GITHUB_REPO, version_prefix="")
+        latest_version, latest_asset = _fetch_release_asset()
 
         # Read current file and extract info
         content = lib.read_file(CONFIG.nix_file)
         current = lib.extract_current_info(CONFIG, content)
+        current_asset = lib.extract_with_pattern(content, ASSET_NAME_PATTERN)
+        if current_asset is None:
+            msg = "Could not extract assetName for gemini-cli"
+            raise ValueError(msg)
 
         # Check for update
-        if current.version == latest_version:
+        if current.version == latest_version and current_asset == latest_asset:
             return lib.UpdateResult(
                 tool_name=CONFIG.tool_name,
                 current=current,
                 latest=None,
                 status=lib.UpdateStatus.UP_TO_DATE,
-                message=f"gemini-cli is up to date at version {latest_version}",
+                message=(
+                    "gemini-cli is up to date at "
+                    f"version {latest_version} ({latest_asset})"
+                ),
             )
 
-        # Calculate hash for binary
-        new_hash = calculate_binary_hash(latest_version)
+        # Calculate hash for release asset
+        new_hash = calculate_binary_hash(latest_version, latest_asset)
 
         # Create new package info
         latest = lib.PackageInfo(
@@ -65,6 +97,11 @@ def main() -> int:
 
         # Apply updates and write
         updated_content = lib.apply_updates(CONFIG, content, latest)
+        updated_content = lib.replace_with_pattern(
+            updated_content,
+            ASSET_NAME_PATTERN,
+            latest_asset,
+        )
         lib.write_file(CONFIG.nix_file, updated_content)
 
         return lib.UpdateResult(
@@ -72,7 +109,10 @@ def main() -> int:
             current=current,
             latest=latest,
             status=lib.UpdateStatus.UPDATED,
-            message=f"Updated gemini-cli from {current.version} to {latest_version}",
+            message=(
+                f"Updated gemini-cli from {current.version} ({current_asset}) "
+                f"to {latest_version} ({latest_asset})"
+            ),
         )
 
     # Execute pipeline

--- a/scripts/update_lib.py
+++ b/scripts/update_lib.py
@@ -189,10 +189,7 @@ def calculate_hash(url: str, *, unpack: bool = True) -> Hash:
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     hash_value = result.stdout.strip()
 
-    # Convert to SRI format
-    sri_cmd = ["nix", "hash", "to-sri", "--type", "sha256", hash_value]
-    sri_result = subprocess.run(sri_cmd, capture_output=True, text=True, check=True)
-    return Hash(sri_result.stdout.strip())
+    return Hash(common.convert_nix_hash_to_sri(hash_value))
 
 
 def calculate_patch_hash(patch_files: tuple[Path, ...]) -> str | None:
@@ -219,16 +216,11 @@ def _convert_sha256_to_sri(hash_value: str) -> Hash | None:
     if hash_value.startswith("sha256-"):
         return Hash(hash_value)
 
-    result = subprocess.run(
-        ["nix", "hash", "to-sri", "--type", "sha256", hash_value],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
+    try:
+        sri_hash = common.convert_nix_hash_to_sri(hash_value)
+    except common.SubprocessError:
         return None
 
-    sri_hash = result.stdout.strip()
     return Hash(sri_hash) if sri_hash.startswith("sha256-") else None
 
 


### PR DESCRIPTION
## Summary
- make the updater scripts compatible with current Nix hash commands across platforms
- support the current Gemini CLI bundled release asset format
- stabilize Codex CLI updates by preserving per-system cargo hashes and making the v8 patching path more robust
- add an explicit AI tools build verification step to the update workflow on both Linux and macOS
- refresh the pinned Claude Code, Codex CLI, Droid, and Gemini CLI package metadata

## Validation
- ran `./scripts/update-ai-tools-all.sh`
- ran `./scripts/build-ai-tools.sh`
- verified the update workflow builds AI tools after updating on Linux and macOS
