### PR TITLE
feat(linux): add cryptsetup package

### DIFF
--- a/config/home-manager/home/packages/linux.nix
+++ b/config/home-manager/home/packages/linux.nix
@@ -11,6 +11,7 @@
       inotify-tools
       zip
       squashfsTools
+      cryptsetup
       wirelesstools
       iw
     ];


### PR DESCRIPTION
## Summary
- add `cryptsetup` to the Linux Home Manager package set

## Why
This makes the `cryptsetup` CLI available in the Linux profile so LUKS-related commands can be used directly from the user environment.

## Verification
- `nix-instantiate --parse config/home-manager/home/packages/linux.nix`
- `git diff --check`
