### PR TITLE
chore: remove codex openai base url env vars

### DIFF
--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -451,7 +451,6 @@ if (and (has-external op) (has-external claudius)) {
   }
   if (has-external codex) {
     set E:CLAUDIUS_SECRET_OPENAI_API_KEY = "op://Private/OpenAI Codex CLI/credential"
-    set E:CLAUDIUS_SECRET_OPENAI_BASE_URL = "{{"$E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT"}}/{{"$E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN"}}/openai"
     fn -codex-wrapper {|@args|
       e:claudius secrets run -- codex $@args
     }

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -159,7 +159,6 @@ if type -q op and type -q claudius
     end
     if type -q codex
         set -x CLAUDIUS_SECRET_OPENAI_API_KEY "op://Private/OpenAI Codex CLI/credential"
-        set -x CLAUDIUS_SECRET_OPENAI_BASE_URL "{{$CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT}}/{{$CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN}}/openai"
         alias codex="claudius secrets run -- codex"
     end
 end


### PR DESCRIPTION
## Summary
- remove the Codex-specific `CLAUDIUS_SECRET_OPENAI_BASE_URL` export from fish
- remove the Codex-specific `CLAUDIUS_SECRET_OPENAI_BASE_URL` export from elvish
- keep the existing Anthropic and Gemini gateway settings unchanged

## Why
- OpenAI's Codex changelog for Codex CLI `0.119.0` on `2026-04-10` includes `Remove OPENAI_BASE_URL config fallback`: https://developers.openai.com/codex/changelog
- Current Codex docs describe `openai_base_url` in `config.toml` as the supported way to change the built-in OpenAI provider base URL, rather than using `OPENAI_BASE_URL` as an environment variable: https://developers.openai.com/codex/config-advanced
- The Codex configuration reference also lists `openai_base_url` as a config key for the built-in `openai` provider: https://developers.openai.com/codex/config-reference
- The current auth/config docs describe custom provider auth via `env_key` or `requires_openai_auth`, which means this repo's Codex-only shell export no longer matches the supported Codex configuration surface: https://developers.openai.com/codex/auth
- OpenAI's docs do not appear to label this specific change as `deprecated`; the precise evidence is that the old `OPENAI_BASE_URL` fallback was removed and the documented replacement is config-based

## Verification
- confirmed there are no remaining `CLAUDIUS_SECRET_OPENAI_BASE_URL` or `OPENAI_BASE_URL` references in `config/fish` or `config/elvish`
- `pre-commit` hooks passed during commit and push