### PR TITLE
fix(gpg-agent): enable headless linux profile

### DIFF
--- a/config/home-manager/services/gpg-agent.nix
+++ b/config/home-manager/services/gpg-agent.nix
@@ -1,10 +1,23 @@
-{ pkgs, ... }:
+args@{
+  pkgs,
+  ...
+}:
+
+let
+  isHeadless = args ? isHeadless && args.isHeadless;
+in
 
 {
   services.gpg-agent = {
     enable = true;
     enableScDaemon = true;
     enableExtraSocket = true;
-    pinentry.package = if pkgs.stdenv.isDarwin then pkgs.pinentry-qt else pkgs.pinentry-gnome3;
+    pinentry.package =
+      if pkgs.stdenv.isDarwin then
+        pkgs.pinentry-qt
+      else if isHeadless then
+        pkgs.pinentry-curses
+      else
+        pkgs.pinentry-gnome3;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -148,6 +148,7 @@
         ./config/home-manager/home/packages/linux.nix
         ./config/home-manager/services/keybase.nix
         ./config/home-manager/services/vscode-server.nix
+        ./config/home-manager/services/gpg-agent.nix
       ];
 
       platformHomeModules =


### PR DESCRIPTION
## Summary
- enable the Home Manager `gpg-agent` service in the headless Linux profile
- switch headless Linux to `pinentry-curses` while keeping desktop Linux on `pinentry-gnome3`
- preserve the existing Darwin `pinentry-qt` configuration

## Validation
- evaluated `user@x86_64-linux-headless` and confirmed `services.gpg-agent.enable = true`
- evaluated `user@x86_64-linux-headless` and confirmed `pinentry.package.pname = pinentry-curses`
- evaluated `user@x86_64-linux` and confirmed `pinentry.package.pname = pinentry-gnome3`
