### PR TITLE
fix(vscode): add chetter remote platform

### DIFF
--- a/config/home-manager/programs/vscode/settings.nix
+++ b/config/home-manager/programs/vscode/settings.nix
@@ -73,6 +73,7 @@
         "remotePlatform" = {
           eto = "linux";
           "eto.stultitia.me" = "linux";
+          "chetter.stultitia.me" = "linux";
           heilwig = "macOS";
           chroe = "macOS";
         };


### PR DESCRIPTION
## Summary
- add `chetter` and `chetter.stultitia.me` to the VS Code Remote SSH platform map
- treat both hostnames as Linux, matching the existing `eto` entries

## Validation
- ran `nix eval --impure --json --expr 'let flake = builtins.getFlake (toString ./.); pkgs = import flake.inputs.nixpkgs { system = builtins.currentSystem; }; settings = import ./config/home-manager/programs/vscode/settings.nix { inherit pkgs; }; in settings.userSettings.remote.SSH.remotePlatform'`