### PR TITLE
feat(home-manager): add cloudflared

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -60,6 +60,7 @@
 
         # DevOps
         docker-compose
+        cloudflared
         etcd_3_5
         kubectl
         kubernetes-helm


### PR DESCRIPTION
## Summary
- add `cloudflared` to the Home Manager package set
- keep this limited to the CLI package only
- do not add any long-running tunnel service configuration

## Context
This is intended for ad-hoc access to customer environments over Cloudflare Tunnel, such as:
- SSH via ProxyCommand / `cloudflared access ssh`
- HTTP access through the tunnel to internal services

The goal here is to make the client available on the development host without turning this machine into a permanently connected tunnel endpoint.

## Verification
- not run (`nix flake check` not executed in this pass)
- reviewed that the change is limited to the package list
