### PR TITLE
fix(claudius): support headless 1password auth

### DIFF
--- a/config/elvish/lib/onepassword.elv
+++ b/config/elvish/lib/onepassword.elv
@@ -73,6 +73,12 @@ fn _account-from-args {|@args|
   }
 }
 
+fn _unset-env-if-set {|name|
+  if (has-env $name) {
+    unset-env $name
+  }
+}
+
 fn _set-session {|session account|
   set-env OP_SESSION $session
   echo (styled "✓ set " green) OP_SESSION
@@ -130,7 +136,86 @@ fn _parse-legacy-signin-output {|output account|
   }
 }
 
+fn use-desktop-integration {
+  _unset-env-if-set OP_SERVICE_ACCOUNT_TOKEN
+  _unset-env-if-set OP_SESSION
+  _unset-env-if-set OP_ACCOUNT
+  _unset-env-if-set OP_CONNECT_HOST
+  _unset-env-if-set OP_CONNECT_TOKEN
+}
+
+fn use-manual-signin {
+  _unset-env-if-set OP_SERVICE_ACCOUNT_TOKEN
+  _unset-env-if-set OP_CONNECT_HOST
+  _unset-env-if-set OP_CONNECT_TOKEN
+
+  if (eq $E:OP_SESSION "") {
+    fail "1Password manual session is not set. Run op-signin first."
+  }
+}
+
+fn _read-service-account-token {|token-path|
+  if (eq $token-path "") {
+    fail "1Password service account token path is empty."
+  }
+
+  if (not ?(test -r $token-path)) {
+    fail "1Password service account token is not readable: "$token-path
+  }
+
+  var token = (str:trim-space (slurp < $token-path))
+  if (eq $token "") {
+    fail "1Password service account token file is empty: "$token-path
+  }
+
+  put $token
+}
+
+fn use-service-account {|token-path|
+  _unset-env-if-set OP_SESSION
+  _unset-env-if-set OP_ACCOUNT
+  _unset-env-if-set OP_CONNECT_HOST
+  _unset-env-if-set OP_CONNECT_TOKEN
+  _unset-env-if-set OP_SERVICE_ACCOUNT_TOKEN
+
+  var token = [(_read-service-account-token $token-path)][0]
+  set-env OP_SERVICE_ACCOUNT_TOKEN $token
+  echo (styled "✓ set " green) OP_SERVICE_ACCOUNT_TOKEN
+}
+
+fn apply-shell-mode {|mode token-path|
+  if (eq $mode "desktop") {
+    use-desktop-integration
+    return
+  }
+
+  if (eq $mode "manual") {
+    _unset-env-if-set OP_SERVICE_ACCOUNT_TOKEN
+    _unset-env-if-set OP_CONNECT_HOST
+    _unset-env-if-set OP_CONNECT_TOKEN
+    return
+  }
+
+  if (eq $mode "service-account") {
+    _unset-env-if-set OP_SESSION
+    _unset-env-if-set OP_ACCOUNT
+    _unset-env-if-set OP_CONNECT_HOST
+    _unset-env-if-set OP_CONNECT_TOKEN
+    _unset-env-if-set OP_SERVICE_ACCOUNT_TOKEN
+
+    var token = [(_read-service-account-token $token-path)][0]
+    set-env OP_SERVICE_ACCOUNT_TOKEN $token
+    return
+  }
+
+  fail "Unsupported 1Password mode: "$mode
+}
+
 fn signin {|@args|
+  _unset-env-if-set OP_SERVICE_ACCOUNT_TOKEN
+  _unset-env-if-set OP_CONNECT_HOST
+  _unset-env-if-set OP_CONNECT_TOKEN
+
   var account = ""
   var parsed-account = [(_account-from-args $@args)]
   if (> (count $parsed-account) 0) {

--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -466,16 +466,11 @@ if (has-external krew) {
   ]
 }
 
-# 1Password auth mode for AI tools.
-# desktop: rely on 1Password CLI app integration (macOS default)
-# manual: run `op-signin` first for GUI Linux sessions
-# service-account: load token from disk for headless Linux
+# Home Manager owns CLAUDIUS_1PASSWORD_* defaults.
 # Legacy CLAUDIUS_OP_* names are accepted only as migration fallbacks.
 if (eq $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH "") {
   if (not (eq $E:CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH "")) {
     set E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = $E:CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
-  } else {
-    set E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = $E:HOME/.config/op/service-accounts/headless-linux-cli.token
   }
 }
 if (has-env CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH) {
@@ -484,21 +479,6 @@ if (has-env CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH) {
 if (eq $E:CLAUDIUS_1PASSWORD_MODE "") {
   if (not (eq $E:CLAUDIUS_OP_MODE "")) {
     set E:CLAUDIUS_1PASSWORD_MODE = $E:CLAUDIUS_OP_MODE
-  } else {
-    var platform = [(uname -s)][0]
-    if (and
-      (eq $platform "Linux")
-      (eq $E:DISPLAY "")
-      (eq $E:WAYLAND_DISPLAY "")
-      (not (or (eq $E:XDG_SESSION_TYPE "x11") (eq $E:XDG_SESSION_TYPE "wayland")))
-      ?(test -r $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH)
-    ) {
-      set E:CLAUDIUS_1PASSWORD_MODE = "service-account"
-    } elif (eq $platform "Linux") {
-      set E:CLAUDIUS_1PASSWORD_MODE = "manual"
-    } else {
-      set E:CLAUDIUS_1PASSWORD_MODE = "desktop"
-    }
   }
 }
 if (has-env CLAUDIUS_OP_MODE) {
@@ -507,10 +487,6 @@ if (has-env CLAUDIUS_OP_MODE) {
 if (eq $E:CLAUDIUS_1PASSWORD_VAULT "") {
   if (not (eq $E:CLAUDIUS_OP_VAULT "")) {
     set E:CLAUDIUS_1PASSWORD_VAULT = $E:CLAUDIUS_OP_VAULT
-  } elif (eq $E:CLAUDIUS_1PASSWORD_MODE "service-account") {
-    set E:CLAUDIUS_1PASSWORD_VAULT = Automation
-  } else {
-    set E:CLAUDIUS_1PASSWORD_VAULT = Private
   }
 }
 if (has-env CLAUDIUS_OP_VAULT) {
@@ -527,7 +503,7 @@ fn op-signin {|@args|
   onepassword:signin $@args
 }
 
-if (has-external op) {
+if (and (has-external op) (not (eq $E:CLAUDIUS_1PASSWORD_MODE ""))) {
   try {
     onepassword:apply-shell-mode $E:CLAUDIUS_1PASSWORD_MODE $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
   } catch e {
@@ -553,12 +529,7 @@ if (and (has-external op) (has-external claudius)) {
       return
     }
 
-    if (eq $E:CLAUDIUS_1PASSWORD_MODE "service-account") {
-      put Automation
-      return
-    }
-
-    put Private
+    put Automation
   }
 
   fn -configure-claudius-secrets {

--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -296,6 +296,65 @@ if ?(test -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh) {
   ]
 }
 
+fn _import-hm-session-vars {
+  if (or (has-env __HM_SESS_VARS_SOURCED) (not (has-external bash))) {
+    return
+  }
+
+  var hm-session-vars = $E:HOME/.nix-profile/etc/profile.d/hm-session-vars.sh
+  if (not ?(test -f $hm-session-vars)) {
+    return
+  }
+
+  try {
+    var exported = (bash -lc '
+source "$1" >/dev/null 2>&1
+printf "__HM_SESS_VARS_SOURCED=%s\n" "$__HM_SESS_VARS_SOURCED"
+printf "CLAUDIUS_1PASSWORD_MODE=%s\n" "$CLAUDIUS_1PASSWORD_MODE"
+printf "CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH=%s\n" "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"
+printf "CLAUDIUS_1PASSWORD_VAULT=%s\n" "$CLAUDIUS_1PASSWORD_VAULT"
+' bash $hm-session-vars | slurp)
+
+    fn import-line {|name value|
+      if (eq $name "__HM_SESS_VARS_SOURCED") {
+        set-env $name $value
+        return
+      }
+
+      if (eq $name "CLAUDIUS_1PASSWORD_MODE") {
+        if (or (has-env CLAUDIUS_1PASSWORD_MODE) (has-env CLAUDIUS_OP_MODE)) {
+          return
+        }
+      } elif (eq $name "CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH") {
+        if (or
+          (has-env CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH)
+          (has-env CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH)
+        ) {
+          return
+        }
+      } elif (eq $name "CLAUDIUS_1PASSWORD_VAULT") {
+        if (or (has-env CLAUDIUS_1PASSWORD_VAULT) (has-env CLAUDIUS_OP_VAULT)) {
+          return
+        }
+      }
+
+      set-env $name $value
+    }
+
+    each {|line|
+      if (not (eq $line "")) {
+        var parts = [(str:split "=" $line)]
+        if (>= (count $parts) 2) {
+          import-line $parts[0] $parts[1]
+        }
+      }
+    } [(str:split "\n" (str:trim-space $exported))]
+  } catch {
+  }
+}
+
+_import-hm-session-vars
+
 # Configure XDG Base Directory
 set E:XDG_CONFIG_HOME = $E:HOME/.config
 
@@ -407,11 +466,55 @@ if (has-external krew) {
   ]
 }
 
-# For Gemini-CLI with 1Password
-if (and (has-external op) (has-external gemini)) {
-  set E:GOOGLE_CLOUD_PROJECT = "op://Private/Vertex AI - personal/project"
-  set E:GOOGLE_CLOUD_LOCATION = "op://Private/Vertex AI - personal/location"
-  set E:GOOGLE_APPLICATION_CREDENTIALS = "op://Private/Vertex AI - personal/credential"
+# 1Password auth mode for AI tools.
+# desktop: rely on 1Password CLI app integration (macOS default)
+# manual: run `op-signin` first for GUI Linux sessions
+# service-account: load token from disk for headless Linux
+# Legacy CLAUDIUS_OP_* names are accepted only as migration fallbacks.
+if (eq $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH "") {
+  if (not (eq $E:CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH "")) {
+    set E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = $E:CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
+  } else {
+    set E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = $E:HOME/.config/op/service-accounts/headless-linux-cli.token
+  }
+}
+if (has-env CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH) {
+  unset-env CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
+}
+if (eq $E:CLAUDIUS_1PASSWORD_MODE "") {
+  if (not (eq $E:CLAUDIUS_OP_MODE "")) {
+    set E:CLAUDIUS_1PASSWORD_MODE = $E:CLAUDIUS_OP_MODE
+  } else {
+    var platform = [(uname -s)][0]
+    if (and
+      (eq $platform "Linux")
+      (eq $E:DISPLAY "")
+      (eq $E:WAYLAND_DISPLAY "")
+      (not (or (eq $E:XDG_SESSION_TYPE "x11") (eq $E:XDG_SESSION_TYPE "wayland")))
+      ?(test -r $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH)
+    ) {
+      set E:CLAUDIUS_1PASSWORD_MODE = "service-account"
+    } elif (eq $platform "Linux") {
+      set E:CLAUDIUS_1PASSWORD_MODE = "manual"
+    } else {
+      set E:CLAUDIUS_1PASSWORD_MODE = "desktop"
+    }
+  }
+}
+if (has-env CLAUDIUS_OP_MODE) {
+  unset-env CLAUDIUS_OP_MODE
+}
+if (eq $E:CLAUDIUS_1PASSWORD_VAULT "") {
+  if (not (eq $E:CLAUDIUS_OP_VAULT "")) {
+    set E:CLAUDIUS_1PASSWORD_VAULT = $E:CLAUDIUS_OP_VAULT
+  } elif (eq $E:CLAUDIUS_1PASSWORD_MODE "service-account") {
+    set E:CLAUDIUS_1PASSWORD_VAULT = Automation
+  } else {
+    set E:CLAUDIUS_1PASSWORD_VAULT = Private
+  }
+}
+if (has-env CLAUDIUS_OP_VAULT) {
+  unset-env CLAUDIUS_OP_VAULT
 }
 
 # 1Password helpers
@@ -424,35 +527,80 @@ fn op-signin {|@args|
   onepassword:signin $@args
 }
 
+if (has-external op) {
+  try {
+    onepassword:apply-shell-mode $E:CLAUDIUS_1PASSWORD_MODE $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
+  } catch e {
+    echo (styled "1Password auth initialization failed:" red) $e >&2
+  }
+}
+
+fn op-sa {|@args|
+  if (not (has-external op)) {
+    echo (styled "1Password CLI (op) not found in PATH" red) >&2
+    return
+  }
+
+  onepassword:use-service-account $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
+  e:op $@args
+}
+
 # Get secrets from 1Password for AI tools
 if (and (has-external op) (has-external claudius)) {
-  set E:CLAUDIUS_SECRET_CF_AIG_ACCOUNT_ID = "op://Private/CLOUDFLARE AI Gateway/Account ID"
-  set E:CLAUDIUS_SECRET_CF_AIG_GATEWAY_ID = "op://Private/CLOUDFLARE AI Gateway/Gateway ID"
-  set E:CLAUDIUS_SECRET_CF_AIG_TOKEN = "op://Private/CLOUDFLARE AI Gateway/credential"
-  set E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT = "op://Private/Personal AI Gateway Credential/endpoint"
-  set E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN = "op://Private/Personal AI Gateway Credential/credential"
+  fn -current-op-vault {
+    if (not (eq $E:CLAUDIUS_1PASSWORD_VAULT "")) {
+      put $E:CLAUDIUS_1PASSWORD_VAULT
+      return
+    }
+
+    if (eq $E:CLAUDIUS_1PASSWORD_MODE "service-account") {
+      put Automation
+      return
+    }
+
+    put Private
+  }
+
+  fn -configure-claudius-secrets {
+    var ai-vault = [(-current-op-vault)][0]
+    set E:CLAUDIUS_SECRET_CF_AIG_ACCOUNT_ID = "op://"$ai-vault"/CLOUDFLARE AI Gateway/Account ID"
+    set E:CLAUDIUS_SECRET_CF_AIG_GATEWAY_ID = "op://"$ai-vault"/CLOUDFLARE AI Gateway/Gateway ID"
+    set E:CLAUDIUS_SECRET_CF_AIG_TOKEN = "op://"$ai-vault"/CLOUDFLARE AI Gateway/credential"
+    set E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT = "op://"$ai-vault"/Personal AI Gateway Credential/endpoint"
+    set E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN = "op://"$ai-vault"/Personal AI Gateway Credential/credential"
+    set E:CLAUDIUS_SECRET_GOOGLE_CLOUD_PROJECT = "op://"$ai-vault"/Vertex AI - personal/project"
+    set E:CLAUDIUS_SECRET_GOOGLE_CLOUD_LOCATION = "op://"$ai-vault"/Vertex AI - personal/location"
+    set E:CLAUDIUS_SECRET_GOOGLE_APPLICATION_CREDENTIALS = "op://"$ai-vault"/Vertex AI - personal/credential"
+    set E:CLAUDIUS_SECRET_OPENAI_API_KEY = "op://"$ai-vault"/OpenAI Codex CLI/credential"
+  }
 
   # Base URLs for AI tools with wrapper functions
   # Note: Use edit:add-var to make functions override external commands
   # Note: Use string concatenation to expand variables inside {{}} for Claudius
+  fn -claudius-tool-wrapper {|tool @args|
+    -configure-claudius-secrets
+    e:claudius secrets run -- $tool $@args
+  }
+
+  -configure-claudius-secrets
+
   if (has-external claude) {
     set E:CLAUDIUS_SECRET_ANTHROPIC_BASE_URL = "{{"$E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT"}}/{{"$E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN"}}/anthropic"
     fn -claude-wrapper {|@args|
-      e:claudius secrets run -- claude $@args
+      -claudius-tool-wrapper claude $@args
     }
     edit:add-var claude~ $-claude-wrapper~
   }
   if (has-external gemini) {
     set E:CLAUDIUS_SECRET_GOOGLE_VERTEX_BASE_URL = "{{"$E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT"}}/{{"$E:CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN"}}/google-vertex-ai"
     fn -gemini-wrapper {|@args|
-      e:claudius secrets run -- gemini $@args
+      -claudius-tool-wrapper gemini $@args
     }
     edit:add-var gemini~ $-gemini-wrapper~
   }
   if (has-external codex) {
-    set E:CLAUDIUS_SECRET_OPENAI_API_KEY = "op://Private/OpenAI Codex CLI/credential"
     fn -codex-wrapper {|@args|
-      e:claudius secrets run -- codex $@args
+      -claudius-tool-wrapper codex $@args
     }
     edit:add-var codex~ $-codex-wrapper~
   }

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -32,6 +32,56 @@ if type -q bass
     end
 end
 
+function __claudius_import_hm_session_vars
+    if set -q __HM_SESS_VARS_SOURCED
+        return
+    end
+
+    function __claudius_import_hm_session_var
+        set -l name $argv[1]
+        set -l value $argv[2]
+
+        switch "$name"
+            case __HM_SESS_VARS_SOURCED
+                set -gx -- $name "$value"
+            case CLAUDIUS_1PASSWORD_MODE
+                if not set -q CLAUDIUS_1PASSWORD_MODE; and not set -q CLAUDIUS_OP_MODE
+                    set -gx -- $name "$value"
+                end
+            case CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
+                if not set -q CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH; and not set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
+                    set -gx -- $name "$value"
+                end
+            case CLAUDIUS_1PASSWORD_VAULT
+                if not set -q CLAUDIUS_1PASSWORD_VAULT; and not set -q CLAUDIUS_OP_VAULT
+                    set -gx -- $name "$value"
+                end
+            case '*'
+                set -gx -- $name "$value"
+        end
+    end
+
+    set -l hm_session_vars "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+    if not test -f "$hm_session_vars"
+        return
+    end
+
+    for line in (bash -lc 'source "$1" >/dev/null 2>&1
+printf "__HM_SESS_VARS_SOURCED=%s\n" "$__HM_SESS_VARS_SOURCED"
+printf "CLAUDIUS_1PASSWORD_MODE=%s\n" "$CLAUDIUS_1PASSWORD_MODE"
+printf "CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH=%s\n" "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"
+printf "CLAUDIUS_1PASSWORD_VAULT=%s\n" "$CLAUDIUS_1PASSWORD_VAULT"' bash "$hm_session_vars")
+        if test -n "$line"
+            set -l parts (string split -m 1 '=' -- "$line")
+            if test (count $parts) -eq 2
+                __claudius_import_hm_session_var $parts[1] "$parts[2]"
+            end
+        end
+    end
+end
+
+__claudius_import_hm_session_vars
+
 # Configure any-nix-shell
 if type -q any-nix-shell
     any-nix-shell fish --info-right | source
@@ -133,33 +183,155 @@ if type -q krew
     set_path "$HOME/.krew/bin"
 end
 
-# For Gemini-CLI
-if type -q op and type -q gemini
-    set -x GOOGLE_CLOUD_PROJECT "op://Private/Vertex AI - personal/project"
-    set -x GOOGLE_CLOUD_LOCATION "op://Private/Vertex AI - personal/location"
-    set -x GOOGLE_APPLICATION_CREDENTIALS "op://Private/Vertex AI - personal/credential"
+# 1Password auth mode for AI tools.
+# desktop: rely on 1Password CLI app integration (macOS default)
+# manual: run `op-signin` first for GUI Linux sessions
+# service-account: load token from disk for headless Linux
+# Legacy CLAUDIUS_OP_* names are accepted only as migration fallbacks.
+if not set -q CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
+    if set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
+        set -gx CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH "$CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH"
+    else
+        set -gx CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH "$HOME/.config/op/service-accounts/headless-linux-cli.token"
+    end
+end
+if set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
+    set -e CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
+end
+if not set -q CLAUDIUS_1PASSWORD_MODE
+    if set -q CLAUDIUS_OP_MODE
+        set -gx CLAUDIUS_1PASSWORD_MODE "$CLAUDIUS_OP_MODE"
+    else
+        set -l claudius_platform (uname -s)
+        set -l claudius_headless 0
+
+        if test -z "$DISPLAY"; and test -z "$WAYLAND_DISPLAY"; and not contains -- "$XDG_SESSION_TYPE" x11 wayland
+            set claudius_headless 1
+        end
+
+        if test "$claudius_platform" = Linux
+            if test "$claudius_headless" = 1; and test -r "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"
+                set -gx CLAUDIUS_1PASSWORD_MODE service-account
+            else
+                set -gx CLAUDIUS_1PASSWORD_MODE manual
+            end
+        else
+            set -gx CLAUDIUS_1PASSWORD_MODE desktop
+        end
+    end
+end
+if set -q CLAUDIUS_OP_MODE
+    set -e CLAUDIUS_OP_MODE
+end
+if not set -q CLAUDIUS_1PASSWORD_VAULT
+    if set -q CLAUDIUS_OP_VAULT
+        set -gx CLAUDIUS_1PASSWORD_VAULT "$CLAUDIUS_OP_VAULT"
+    else if test "$CLAUDIUS_1PASSWORD_MODE" = "service-account"
+        set -gx CLAUDIUS_1PASSWORD_VAULT Automation
+    else
+        set -gx CLAUDIUS_1PASSWORD_VAULT Private
+    end
+end
+if set -q CLAUDIUS_OP_VAULT
+    set -e CLAUDIUS_OP_VAULT
+end
+
+function __claudius_apply_default_op_auth
+    switch "$CLAUDIUS_1PASSWORD_MODE"
+        case desktop
+            set -e OP_SERVICE_ACCOUNT_TOKEN OP_SESSION OP_ACCOUNT OP_CONNECT_HOST OP_CONNECT_TOKEN
+        case manual
+            set -e OP_SERVICE_ACCOUNT_TOKEN OP_CONNECT_HOST OP_CONNECT_TOKEN
+        case service-account
+            set -e OP_SESSION OP_ACCOUNT OP_CONNECT_HOST OP_CONNECT_TOKEN OP_SERVICE_ACCOUNT_TOKEN
+            if not test -r "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"
+                echo "1Password service account token is not readable: $CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH" >&2
+                return 1
+            end
+            set -gx OP_SERVICE_ACCOUNT_TOKEN (string trim -- (cat "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"))
+            if test -z "$OP_SERVICE_ACCOUNT_TOKEN"
+                echo "1Password service account token file is empty: $CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH" >&2
+                return 1
+            end
+        case '*'
+            echo "Unsupported CLAUDIUS_1PASSWORD_MODE: $CLAUDIUS_1PASSWORD_MODE" >&2
+            return 1
+    end
+end
+
+function __claudius_current_op_vault
+    if set -q CLAUDIUS_1PASSWORD_VAULT
+        echo "$CLAUDIUS_1PASSWORD_VAULT"
+    else if test "$CLAUDIUS_1PASSWORD_MODE" = "service-account"
+        echo Automation
+    else
+        echo Private
+    end
+end
+
+function __claudius_export_secrets
+    set -l ai_vault (__claudius_current_op_vault)
+    set -gx CLAUDIUS_SECRET_CF_AIG_ACCOUNT_ID "op://$ai_vault/CLOUDFLARE AI Gateway/Account ID"
+    set -gx CLAUDIUS_SECRET_CF_AIG_GATEWAY_ID "op://$ai_vault/CLOUDFLARE AI Gateway/Gateway ID"
+    set -gx CLAUDIUS_SECRET_CF_AIG_TOKEN "op://$ai_vault/CLOUDFLARE AI Gateway/credential"
+    set -gx CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT "op://$ai_vault/Personal AI Gateway Credential/endpoint"
+    set -gx CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN "op://$ai_vault/Personal AI Gateway Credential/credential"
+    set -gx CLAUDIUS_SECRET_GOOGLE_CLOUD_PROJECT "op://$ai_vault/Vertex AI - personal/project"
+    set -gx CLAUDIUS_SECRET_GOOGLE_CLOUD_LOCATION "op://$ai_vault/Vertex AI - personal/location"
+    set -gx CLAUDIUS_SECRET_GOOGLE_APPLICATION_CREDENTIALS "op://$ai_vault/Vertex AI - personal/credential"
+    set -gx CLAUDIUS_SECRET_OPENAI_API_KEY "op://$ai_vault/OpenAI Codex CLI/credential"
+end
+
+function __claudius_run_tool
+    set -l tool $argv[1]
+    set -e argv[1]
+
+    __claudius_export_secrets
+    command claudius secrets run -- $tool $argv
+end
+
+function op-sa --description 'Run op using the configured 1Password service account'
+    set -l previous_mode $CLAUDIUS_1PASSWORD_MODE
+    set -gx CLAUDIUS_1PASSWORD_MODE service-account
+
+    __claudius_apply_default_op_auth
+    or begin
+        set -l prepare_status $status
+        set -gx CLAUDIUS_1PASSWORD_MODE $previous_mode
+        return $prepare_status
+    end
+
+    command op $argv
+    set -l status_code $status
+    set -gx CLAUDIUS_1PASSWORD_MODE $previous_mode
+    return $status_code
 end
 
 # Get secrets from 1Password
+if type -q op
+    __claudius_apply_default_op_auth
+end
+
 if type -q op and type -q claudius
-    set -x CLAUDIUS_SECRET_CF_AIG_ACCOUNT_ID "op://Private/CLOUDFLARE AI Gateway/Account ID"
-    set -x CLAUDIUS_SECRET_CF_AIG_GATEWAY_ID "op://Private/CLOUDFLARE AI Gateway/Gateway ID"
-    set -x CLAUDIUS_SECRET_CF_AIG_TOKEN "op://Private/CLOUDFLARE AI Gateway/credential"
-    set -x CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT "op://Private/Personal AI Gateway Credential/endpoint"
-    set -x CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN "op://Private/Personal AI Gateway Credential/credential"
+    __claudius_export_secrets
 
     # Base URLs
     if type -q claude
         set -x CLAUDIUS_SECRET_ANTHROPIC_BASE_URL "{{$CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT}}/{{$CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN}}/anthropic"
-        alias claude="claudius secrets run -- claude"
+        function claude --wraps claude
+            __claudius_run_tool claude $argv
+        end
     end
     if type -q gemini
         set -x CLAUDIUS_SECRET_GOOGLE_VERTEX_BASE_URL "{{$CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_ENDPOINT}}/{{$CLAUDIUS_SECRET_PERSONAL_AI_GATEWAY_TOKEN}}/google-vertex-ai"
-        alias gemini="claudius secrets run -- gemini"
+        function gemini --wraps gemini
+            __claudius_run_tool gemini $argv
+        end
     end
     if type -q codex
-        set -x CLAUDIUS_SECRET_OPENAI_API_KEY "op://Private/OpenAI Codex CLI/credential"
-        alias codex="claudius secrets run -- codex"
+        function codex --wraps codex
+            __claudius_run_tool codex $argv
+        end
     end
 end
 

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -183,16 +183,11 @@ if type -q krew
     set_path "$HOME/.krew/bin"
 end
 
-# 1Password auth mode for AI tools.
-# desktop: rely on 1Password CLI app integration (macOS default)
-# manual: run `op-signin` first for GUI Linux sessions
-# service-account: load token from disk for headless Linux
+# Home Manager owns CLAUDIUS_1PASSWORD_* defaults.
 # Legacy CLAUDIUS_OP_* names are accepted only as migration fallbacks.
 if not set -q CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
     if set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
         set -gx CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH "$CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH"
-    else
-        set -gx CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH "$HOME/.config/op/service-accounts/headless-linux-cli.token"
     end
 end
 if set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
@@ -201,23 +196,6 @@ end
 if not set -q CLAUDIUS_1PASSWORD_MODE
     if set -q CLAUDIUS_OP_MODE
         set -gx CLAUDIUS_1PASSWORD_MODE "$CLAUDIUS_OP_MODE"
-    else
-        set -l claudius_platform (uname -s)
-        set -l claudius_headless 0
-
-        if test -z "$DISPLAY"; and test -z "$WAYLAND_DISPLAY"; and not contains -- "$XDG_SESSION_TYPE" x11 wayland
-            set claudius_headless 1
-        end
-
-        if test "$claudius_platform" = Linux
-            if test "$claudius_headless" = 1; and test -r "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"
-                set -gx CLAUDIUS_1PASSWORD_MODE service-account
-            else
-                set -gx CLAUDIUS_1PASSWORD_MODE manual
-            end
-        else
-            set -gx CLAUDIUS_1PASSWORD_MODE desktop
-        end
     end
 end
 if set -q CLAUDIUS_OP_MODE
@@ -226,10 +204,6 @@ end
 if not set -q CLAUDIUS_1PASSWORD_VAULT
     if set -q CLAUDIUS_OP_VAULT
         set -gx CLAUDIUS_1PASSWORD_VAULT "$CLAUDIUS_OP_VAULT"
-    else if test "$CLAUDIUS_1PASSWORD_MODE" = "service-account"
-        set -gx CLAUDIUS_1PASSWORD_VAULT Automation
-    else
-        set -gx CLAUDIUS_1PASSWORD_VAULT Private
     end
 end
 if set -q CLAUDIUS_OP_VAULT
@@ -262,10 +236,8 @@ end
 function __claudius_current_op_vault
     if set -q CLAUDIUS_1PASSWORD_VAULT
         echo "$CLAUDIUS_1PASSWORD_VAULT"
-    else if test "$CLAUDIUS_1PASSWORD_MODE" = "service-account"
-        echo Automation
     else
-        echo Private
+        echo Automation
     end
 end
 
@@ -291,24 +263,39 @@ function __claudius_run_tool
 end
 
 function op-sa --description 'Run op using the configured 1Password service account'
-    set -l previous_mode $CLAUDIUS_1PASSWORD_MODE
+    set -l had_previous_mode 0
+    set -l previous_mode
+
+    if set -q CLAUDIUS_1PASSWORD_MODE
+        set had_previous_mode 1
+        set previous_mode "$CLAUDIUS_1PASSWORD_MODE"
+    end
+
     set -gx CLAUDIUS_1PASSWORD_MODE service-account
 
     __claudius_apply_default_op_auth
     or begin
         set -l prepare_status $status
-        set -gx CLAUDIUS_1PASSWORD_MODE $previous_mode
+        if test $had_previous_mode -eq 1
+            set -gx CLAUDIUS_1PASSWORD_MODE "$previous_mode"
+        else
+            set -e CLAUDIUS_1PASSWORD_MODE
+        end
         return $prepare_status
     end
 
     command op $argv
     set -l status_code $status
-    set -gx CLAUDIUS_1PASSWORD_MODE $previous_mode
+    if test $had_previous_mode -eq 1
+        set -gx CLAUDIUS_1PASSWORD_MODE "$previous_mode"
+    else
+        set -e CLAUDIUS_1PASSWORD_MODE
+    end
     return $status_code
 end
 
 # Get secrets from 1Password
-if type -q op
+if type -q op; and set -q CLAUDIUS_1PASSWORD_MODE
     __claudius_apply_default_op_auth
 end
 

--- a/config/home-manager/home.nix
+++ b/config/home-manager/home.nix
@@ -13,6 +13,7 @@
   imports = [
     ./home/file.nix
     ./home/packages/default.nix
+    ./home/sessionVariables.nix
     ./programs
   ];
 

--- a/config/home-manager/home/sessionVariables.nix
+++ b/config/home-manager/home/sessionVariables.nix
@@ -19,13 +19,7 @@ let
       "manual"
     else
       null;
-  onepasswordVault =
-    if isLinux && isHeadless then
-      "Automation"
-    else if onepasswordMode != null then
-      "Private"
-    else
-      null;
+  onepasswordVault = if onepasswordMode != null then "Automation" else null;
   claudiusConfigText = lib.concatStrings [
     ''
       # Managed by Home Manager. Edit dotfiles instead of this file.
@@ -45,14 +39,11 @@ let
   ];
 in
 {
-  home.sessionVariables =
-    lib.optionalAttrs (onepasswordMode != null) {
-      CLAUDIUS_1PASSWORD_MODE = onepasswordMode;
-      CLAUDIUS_1PASSWORD_VAULT = onepasswordVault;
-    }
-    // lib.optionalAttrs (isLinux && isHeadless) {
-      CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = serviceAccountTokenEnvPath;
-    };
+  home.sessionVariables = lib.optionalAttrs (onepasswordMode != null) {
+    CLAUDIUS_1PASSWORD_MODE = onepasswordMode;
+    CLAUDIUS_1PASSWORD_VAULT = onepasswordVault;
+    CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = serviceAccountTokenEnvPath;
+  };
 
   xdg.configFile = lib.optionalAttrs (onepasswordMode != null) {
     "claudius/config.toml" = {

--- a/config/home-manager/home/sessionVariables.nix
+++ b/config/home-manager/home/sessionVariables.nix
@@ -1,1 +1,63 @@
-{ sessionVariables = { }; }
+{
+  lib,
+  system,
+  ...
+}@args:
+
+let
+  isDarwin = lib.hasSuffix "-darwin" system;
+  isLinux = lib.hasSuffix "-linux" system;
+  isHeadless = args ? isHeadless && args.isHeadless;
+  serviceAccountTokenEnvPath = "$HOME/.config/op/service-accounts/headless-linux-cli.token";
+  serviceAccountTokenConfigPath = "~/.config/op/service-accounts/headless-linux-cli.token";
+  onepasswordMode =
+    if isDarwin then
+      "desktop"
+    else if isLinux && isHeadless then
+      "service-account"
+    else if isLinux then
+      "manual"
+    else
+      null;
+  onepasswordVault =
+    if isLinux && isHeadless then
+      "Automation"
+    else if onepasswordMode != null then
+      "Private"
+    else
+      null;
+  claudiusConfigText = lib.concatStrings [
+    ''
+      # Managed by Home Manager. Edit dotfiles instead of this file.
+      [default]
+      agent = "claude"
+      context-file = "CLAUDE.md"
+
+      [secret-manager]
+      type = "1password"
+
+      [secret-manager.onepassword]
+      mode = "${onepasswordMode}"
+    ''
+    (lib.optionalString (isLinux && isHeadless) ''
+      service-account-token-path = "${serviceAccountTokenConfigPath}"
+    '')
+  ];
+in
+{
+  home.sessionVariables =
+    lib.optionalAttrs (onepasswordMode != null) {
+      CLAUDIUS_1PASSWORD_MODE = onepasswordMode;
+      CLAUDIUS_1PASSWORD_VAULT = onepasswordVault;
+    }
+    // lib.optionalAttrs (isLinux && isHeadless) {
+      CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH = serviceAccountTokenEnvPath;
+    };
+
+  xdg.configFile = lib.optionalAttrs (onepasswordMode != null) {
+    "claudius/config.toml" = {
+      force = true;
+      text = claudiusConfigText;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- rebase the existing headless 1Password work onto the latest `main`
- add headless/manual 1Password mode support for Claudius shell integration
- import Home Manager session variables from fish and elvish
- wire `home/sessionVariables.nix` into `home.nix`

## Why
The original change introduced the headless 1Password flow, but the Home Manager session variable module was not imported, so the shell-side defaults were not fully wired in. This follow-up keeps the branch coherent by making the generated session variables available to fish and elvish and by selecting the appropriate default mode on Linux.

## Verification
- commit signatures are present on the local commits used for this branch
- not run (`nix flake check` not executed in this pass)
- confirmed that the unrelated `flake.lock` diff is already included in `main`, so it is intentionally excluded here
