### PR TITLE
fix(claudius): reload HM session vars when sourced flag is set

### DIFF
--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -297,7 +297,7 @@ if ?(test -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh) {
 }
 
 fn _import-hm-session-vars {
-  if (or (has-env __HM_SESS_VARS_SOURCED) (not (has-external bash))) {
+  if (not (has-external bash)) {
     return
   }
 
@@ -308,6 +308,7 @@ fn _import-hm-session-vars {
 
   try {
     var exported = (bash -lc '
+unset __HM_SESS_VARS_SOURCED
 source "$1" >/dev/null 2>&1
 printf "__HM_SESS_VARS_SOURCED=%s\n" "$__HM_SESS_VARS_SOURCED"
 printf "CLAUDIUS_1PASSWORD_MODE=%s\n" "$CLAUDIUS_1PASSWORD_MODE"

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -33,10 +33,6 @@ if type -q bass
 end
 
 function __claudius_import_hm_session_vars
-    if set -q __HM_SESS_VARS_SOURCED
-        return
-    end
-
     function __claudius_import_hm_session_var
         set -l name $argv[1]
         set -l value $argv[2]
@@ -66,7 +62,8 @@ function __claudius_import_hm_session_vars
         return
     end
 
-    for line in (bash -lc 'source "$1" >/dev/null 2>&1
+    for line in (bash -lc 'unset __HM_SESS_VARS_SOURCED
+source "$1" >/dev/null 2>&1
 printf "__HM_SESS_VARS_SOURCED=%s\n" "$__HM_SESS_VARS_SOURCED"
 printf "CLAUDIUS_1PASSWORD_MODE=%s\n" "$CLAUDIUS_1PASSWORD_MODE"
 printf "CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH=%s\n" "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"


### PR DESCRIPTION
## Summary
- stop skipping the fish/elvish Home Manager import just because `__HM_SESS_VARS_SOURCED` is already present
- unset `__HM_SESS_VARS_SOURCED` inside the subprocess that sources `hm-session-vars.sh`
- keep importing the Claudius 1Password variables even when the login environment already carries the sourced sentinel

## Root cause
On headless Linux, a fresh login could inherit `__HM_SESS_VARS_SOURCED=1` without all `CLAUDIUS_1PASSWORD_*` variables. In that state, the shell-side import either returned early or sourced `hm-session-vars.sh` in a subprocess where Home Manager immediately no-op'd, leaving `CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH` empty.

## Verification
- `fish -n config/fish/config.fish`
- reproduced that sourcing `hm-session-vars.sh` with inherited `__HM_SESS_VARS_SOURCED=1` returns an empty token path before the fix
- confirmed that unsetting the sentinel before sourcing restores `CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH`
