### PR TITLE
fix(claudius): import HM values over empty env vars

### DIFF
--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -323,18 +323,24 @@ printf "CLAUDIUS_1PASSWORD_VAULT=%s\n" "$CLAUDIUS_1PASSWORD_VAULT"
       }
 
       if (eq $name "CLAUDIUS_1PASSWORD_MODE") {
-        if (or (has-env CLAUDIUS_1PASSWORD_MODE) (has-env CLAUDIUS_OP_MODE)) {
+        if (or
+          (not (eq $E:CLAUDIUS_1PASSWORD_MODE ""))
+          (not (eq $E:CLAUDIUS_OP_MODE ""))
+        ) {
           return
         }
       } elif (eq $name "CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH") {
         if (or
-          (has-env CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH)
-          (has-env CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH)
+          (not (eq $E:CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH ""))
+          (not (eq $E:CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH ""))
         ) {
           return
         }
       } elif (eq $name "CLAUDIUS_1PASSWORD_VAULT") {
-        if (or (has-env CLAUDIUS_1PASSWORD_VAULT) (has-env CLAUDIUS_OP_VAULT)) {
+        if (or
+          (not (eq $E:CLAUDIUS_1PASSWORD_VAULT ""))
+          (not (eq $E:CLAUDIUS_OP_VAULT ""))
+        ) {
           return
         }
       }

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -41,16 +41,22 @@ function __claudius_import_hm_session_vars
             case __HM_SESS_VARS_SOURCED
                 set -gx -- $name "$value"
             case CLAUDIUS_1PASSWORD_MODE
-                if not set -q CLAUDIUS_1PASSWORD_MODE; and not set -q CLAUDIUS_OP_MODE
-                    set -gx -- $name "$value"
+                if not set -q CLAUDIUS_1PASSWORD_MODE; or test -z "$CLAUDIUS_1PASSWORD_MODE"
+                    if not set -q CLAUDIUS_OP_MODE; or test -z "$CLAUDIUS_OP_MODE"
+                        set -gx -- $name "$value"
+                    end
                 end
             case CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH
-                if not set -q CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH; and not set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH
-                    set -gx -- $name "$value"
+                if not set -q CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH; or test -z "$CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH"
+                    if not set -q CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH; or test -z "$CLAUDIUS_OP_SERVICE_ACCOUNT_TOKEN_PATH"
+                        set -gx -- $name "$value"
+                    end
                 end
             case CLAUDIUS_1PASSWORD_VAULT
-                if not set -q CLAUDIUS_1PASSWORD_VAULT; and not set -q CLAUDIUS_OP_VAULT
-                    set -gx -- $name "$value"
+                if not set -q CLAUDIUS_1PASSWORD_VAULT; or test -z "$CLAUDIUS_1PASSWORD_VAULT"
+                    if not set -q CLAUDIUS_OP_VAULT; or test -z "$CLAUDIUS_OP_VAULT"
+                        set -gx -- $name "$value"
+                    end
                 end
             case '*'
                 set -gx -- $name "$value"


### PR DESCRIPTION
## Summary
- let fish and Elvish import Home Manager's `CLAUDIUS_1PASSWORD_*` values when the current env vars exist but are empty
- keep explicit non-empty `CLAUDIUS_1PASSWORD_*` and legacy `CLAUDIUS_OP_*` overrides winning over Home Manager
- avoid the headless Linux login warning where Elvish starts in `service-account` mode with an empty token path

## Root cause
The previous import logic only checked whether a variable existed. On headless Linux, the login environment could already contain `CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH=` as an empty variable. In that case the shell-side Home Manager import refused to overwrite it, leaving Elvish to call `apply-shell-mode` with an empty token path.

## Verification
- `fish -n config/fish/config.fish`
- local reproduction that a subprocess sourcing `hm-session-vars.sh` can yield empty values when the sentinel is inherited
- local fish reproduction that an empty `CLAUDIUS_1PASSWORD_SERVICE_ACCOUNT_TOKEN_PATH` is now replaced by the Home Manager value during import
