### PR TITLE
chore(shell): clean up obsolete local CLI state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .direnv
+.codex
+!.codex/
+!.codex/**
 Brewfile.lock.json
 dist-*
 result

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -109,11 +109,6 @@ if type -q kitty
     alias ssh="TERM=xterm-256color $(which ssh)"
 end
 
-# Configure fzf
-if type -q fzf
-    set -U FZF_LEGACY_KEYBINDINGS 0
-end
-
 # Configure atuin (shell history in SQLite)
 if type -q atuin
     atuin init fish | source


### PR DESCRIPTION
## Summary
- drop the obsolete fish `FZF_LEGACY_KEYBINDINGS` universal setting now that this repo no longer relies on the legacy fish fzf plugin path
- ignore a stray root `/.codex` file while still allowing an intentional `/.codex/` project directory to be committed later

## Verification
- `fish` pre-commit hook on `config/fish/config.fish`
- `editorconfig-checker` on `.gitignore`