### PR TITLE
fix(vscode): align insiders paths

### DIFF
--- a/config/home-manager/programs/vscode/default.nix
+++ b/config/home-manager/programs/vscode/default.nix
@@ -1,9 +1,15 @@
-{ pkgs, lib, ... }:
+{
+  pkgs,
+  lib,
+  home-manager,
+  ...
+}:
 
 let
   extensions = import ./extensions.nix;
   settings = import ./settings.nix { inherit pkgs; };
   metadata = import ./metadata.nix;
+  mkVscodeModule = import "${home-manager}/modules/programs/vscode/mkVscodeModule.nix";
 
   inherit (pkgs.stdenv.hostPlatform) system;
 
@@ -23,72 +29,89 @@ let
 
   inherit (metadata) commit;
   sha256 = metadata.sha256.${system} or (throw "No sha256 for system: ${system}");
+
+  vscodeInsidersPackage = (pkgs.vscode.override { isInsiders = true; }).overrideAttrs (oldAttrs: rec {
+    pname = "vscode-insiders";
+    version = "${metadata.version}-${commit}";
+    src = builtins.fetchurl {
+      name = "${pname}-${version}.${platformInfo.archive}";
+      url = metadata.url.${system} or (throw "No URL for system: ${system}");
+      inherit sha256;
+    };
+    buildInputs =
+      oldAttrs.buildInputs
+      ++ [
+        pkgs.krb5
+      ]
+      ++ lib.optionals pkgs.stdenv.isLinux [
+        pkgs.webkitgtk_4_1
+        pkgs.libsoup_3
+      ];
+    runtimeDependencies = lib.optionals pkgs.stdenv.isLinux (
+      oldAttrs.runtimeDependencies
+      ++ [
+        pkgs.libsecret
+      ]
+    );
+    urlHandlerDesktopItem = pkgs.makeDesktopItem {
+      name = "code-insiders-url-handler";
+      desktopName = "Visual Studio Code - Insiders - URL Handler";
+      comment = "Code Editing. Redefined.";
+      genericName = "Text Editor";
+      exec = "code-insiders" + " --open-url %U";
+      icon = "code";
+      startupNotify = true;
+      categories = [
+        "Utility"
+        "TextEditor"
+        "Development"
+        "IDE"
+      ];
+      mimeTypes = [ "x-scheme-handler/${pname}" ];
+      keywords = [ "vscode" ];
+      noDisplay = true;
+    };
+    postPatch = lib.optionalString pkgs.stdenv.isLinux ''
+      # this is a fix for "save as root" functionality
+      packed="resources/app/node_modules.asar"
+      unpacked="resources/app/node_modules"
+      asar extract "$packed" "$unpacked"
+      substituteInPlace $unpacked/@vscode/sudo-prompt/index.js \
+        --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
+        --replace "/bin/bash" "${pkgs.bash}/bin/bash"
+      rm -rf "$packed"
+
+      # without this symlink loading JsChardet, the library that is used for auto encoding detection when files.autoGuessEncoding is true,
+      # fails to load with: electron/js2c/renderer_init: Error: Cannot find module 'jschardet'
+      # and the window immediately closes which renders VSCode unusable
+      # see https://github.com/NixOS/nixpkgs/issues/152939 for full log
+      ln -rs "$unpacked" "$packed"
+    '';
+  });
 in
 {
-  programs.vscode = {
-    enable = true;
-    mutableExtensionsDir = false;
-    package = (pkgs.vscode.override { isInsiders = true; }).overrideAttrs (oldAttrs: rec {
-      pname = "vscode-insiders";
-      version = "${metadata.version}-${commit}";
-      src = builtins.fetchurl {
-        name = "${pname}-${version}.${platformInfo.archive}";
-        url = metadata.url.${system} or (throw "No URL for system: ${system}");
-        inherit sha256;
-      };
-      buildInputs =
-        oldAttrs.buildInputs
-        ++ [
-          pkgs.krb5
-        ]
-        ++ lib.optionals pkgs.stdenv.isLinux [
-          pkgs.webkitgtk_4_1
-          pkgs.libsoup_3
-        ];
-      runtimeDependencies = lib.optionals pkgs.stdenv.isLinux (
-        oldAttrs.runtimeDependencies
-        ++ [
-          pkgs.libsecret
-        ]
-      );
-      urlHandlerDesktopItem = pkgs.makeDesktopItem {
-        name = "code-insiders-url-handler";
-        desktopName = "Visual Studio Code - Insiders - URL Handler";
-        comment = "Code Editing. Redefined.";
-        genericName = "Text Editor";
-        exec = "code-insiders" + " --open-url %U";
-        icon = "code";
-        startupNotify = true;
-        categories = [
-          "Utility"
-          "TextEditor"
-          "Development"
-          "IDE"
-        ];
-        mimeTypes = [ "x-scheme-handler/${pname}" ];
-        keywords = [ "vscode" ];
-        noDisplay = true;
-      };
-      postPatch = lib.optionalString pkgs.stdenv.isLinux ''
-        # this is a fix for "save as root" functionality
-        packed="resources/app/node_modules.asar"
-        unpacked="resources/app/node_modules"
-        asar extract "$packed" "$unpacked"
-        substituteInPlace $unpacked/@vscode/sudo-prompt/index.js \
-          --replace "/usr/bin/pkexec" "/run/wrappers/bin/pkexec" \
-          --replace "/bin/bash" "${pkgs.bash}/bin/bash"
-        rm -rf "$packed"
+  imports = [
+    (mkVscodeModule {
+      modulePath = [
+        "programs"
+        "vscodeInsiders"
+      ];
+      name = "Visual Studio Code - Insiders";
+      packageName = "vscode";
+      nameShort = "Code - Insiders";
+      dataFolderName = ".vscode-insiders";
+    })
+  ];
 
-        # without this symlink loading JsChardet, the library that is used for auto encoding detection when files.autoGuessEncoding is true,
-        # fails to load with: electron/js2c/renderer_init: Error: Cannot find module 'jschardet'
-        # and the window immediately closes which renders VSCode unusable
-        # see https://github.com/NixOS/nixpkgs/issues/152939 for full log
-        ln -rs "$unpacked" "$packed"
-      '';
-    });
-    profiles.default = {
-      extensions = pkgs.vscode-utils.extensionsFromVscodeMarketplace extensions;
-      inherit (settings) userSettings;
+  config = {
+    programs.vscodeInsiders = {
+      enable = true;
+      mutableExtensionsDir = false;
+      package = vscodeInsidersPackage;
+      profiles.default = {
+        extensions = pkgs.vscode-utils.extensionsFromVscodeMarketplace extensions;
+        inherit (settings) userSettings;
+      };
     };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -179,7 +179,11 @@
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = {
-            inherit system nixos-vscode-server;
+            inherit
+              system
+              home-manager
+              nixos-vscode-server
+              ;
           }
           // lib.optionalAttrs headless {
             isHeadless = true;


### PR DESCRIPTION
## Summary
- add a local `programs.vscodeInsiders` Home Manager module that reuses the upstream VS Code module builder with `Code - Insiders` and `.vscode-insiders` paths
- keep the existing custom Insiders package override while moving settings and marketplace extensions onto the correct Insiders directories
- pass the `home-manager` flake input through `extraSpecialArgs` so the local module can import the upstream builder

## Testing
- `nix build .#homeConfigurations.aarch64-darwin.activationPackage --impure --no-link`
- `home-manager switch -b backup --flake .#aarch64-darwin --impure`