### PR TITLE
feat(skills): add repository baseline skill

### DIFF
--- a/config/claudius/skills/catalog.yaml
+++ b/config/claudius/skills/catalog.yaml
@@ -9,7 +9,7 @@ categories:
     description: Search, context maintenance, and git authoring helpers.
   foundation:
     title: Cross-Project Foundation
-    description: Bootstrap, automation, Nix, git hook, and hygiene skills reused across stacks.
+    description: Repository governance, bootstrap, automation, Nix, git hook, and hygiene skills reused across stacks.
   frontend-typescript:
     title: Frontend / TypeScript
     description: JavaScript, TypeScript, and stylesheet quality gates.
@@ -38,6 +38,9 @@ skills:
   suggest-commit:
     category: workflow
     kind: utility
+  setup-repository-baseline:
+    category: foundation
+    kind: bootstrap
   setup-nix-flake:
     category: foundation
     kind: bootstrap

--- a/config/claudius/skills/inventory.yaml
+++ b/config/claudius/skills/inventory.yaml
@@ -101,6 +101,16 @@ skills:
       Still useful as a helper, but commit authoring guidance is secondary to
       repository-wide change policy and PR-title enforcement.
 
+  setup-repository-baseline:
+    topic: foundation
+    role: orchestrator
+    exposure: primary
+    future_action: keep-as-primary-entry-point
+    successor: []
+    rationale: >-
+      This is the source-of-truth policy surface for repository collaboration.
+      Hosted enforcement and local hooks should compose around it, not replace it.
+
   setup-nix-flake:
     topic: foundation
     role: substrate

--- a/config/claudius/skills/roadmap.md
+++ b/config/claudius/skills/roadmap.md
@@ -4,6 +4,9 @@ This roadmap turns the current skills collection into a more natural structure
 for modern OSS teams that want shared repository guardrails first and local
 tooling second.
 
+Status: `setup-repository-baseline` is now the first implemented primary skill.
+The remaining items below are still open.
+
 ## Target shape
 
 ### 1. Repository governance first

--- a/config/claudius/skills/setup-repository-baseline/assets/CHANGELOG.md.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/CHANGELOG.md.template
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project should be documented in this file.
+
+This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and uses Semantic Versioning where that fits the repository's release model.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Security

--- a/config/claudius/skills/setup-repository-baseline/assets/CODEOWNERS.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/CODEOWNERS.template
@@ -1,0 +1,5 @@
+# Prefer team handles for organization repositories when available.
+# Keep this file small at first and add path-specific ownership as the
+# repository grows.
+
+* __PRIMARY_OWNER__

--- a/config/claudius/skills/setup-repository-baseline/assets/CONTRIBUTING.md.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/CONTRIBUTING.md.template
@@ -1,0 +1,65 @@
+# Contributing to __REPOSITORY_NAME__
+
+Thanks for contributing. This repository prefers small, reviewable changes and
+clear source-of-truth documentation.
+
+## Before You Start
+
+- Search existing issues and pull requests before opening a new one.
+- Open or comment on an issue first for larger changes so the approach can be
+  aligned before implementation.
+- Do not report security issues in public issues. Follow `SECURITY.md` instead.
+
+## Working Model
+
+- Branch from `__DEFAULT_BRANCH__`.
+- Keep each pull request focused on one logical change.
+- Update tests, docs, and `CHANGELOG.md` when behavior or contributor-facing
+  workflows change.
+- Prefer follow-up pull requests over one oversized branch.
+
+Recommended branch prefixes:
+
+- `feat/`
+- `fix/`
+- `docs/`
+- `chore/`
+- `refactor/`
+- `test/`
+
+## Pull Requests
+
+Each pull request should explain:
+
+- what changed
+- why it changed
+- how it was verified
+- any operational or rollout risk
+
+Prefer pull request titles in this format:
+
+```text
+type(scope): summary
+```
+
+Use an omitted scope when a scoped title would add noise. If the repository uses
+squash merge, treat the pull request title as the canonical change summary.
+
+## Reviews
+
+- Self-review before requesting review.
+- Resolve review threads with code changes or explicit rationale.
+- Keep review discussions attached to the relevant code or document section.
+
+## Releases and Changelog
+
+- Add contributor-visible changes to `CHANGELOG.md` under `Unreleased`.
+- Keep release notes aligned with the changelog and the pull request title.
+- If a change affects compatibility, migrations, or security posture, call it
+  out explicitly.
+
+## Validation
+
+Run the repository's documented validation steps before opening a pull request.
+If the repository later adopts automated guardrails, follow those instructions as
+the execution path for local verification.

--- a/config/claudius/skills/setup-repository-baseline/assets/SECURITY.md.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/SECURITY.md.template
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+By default, only the active default branch is supported for security fixes.
+Older releases are unsupported unless this repository later documents a separate
+maintenance policy.
+
+| Version | Supported |
+| --- | --- |
+| `__DEFAULT_BRANCH__` | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+Do not open a public issue for security reports.
+
+Report vulnerabilities to `__SECURITY_CONTACT__` with enough detail to reproduce
+and assess the issue:
+
+- affected versions, branches, or commits
+- impact and expected security boundary
+- reproduction steps or proof of concept
+- suggested mitigation if known
+
+## Disclosure Expectations
+
+Maintainers should acknowledge reports promptly and coordinate disclosure after a
+fix or mitigation is available. Keep the report private until maintainers confirm
+that public disclosure is safe.

--- a/config/claudius/skills/setup-repository-baseline/assets/bug_report.yml.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/bug_report.yml.template
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report a reproducible defect in the project.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report.
+        Please provide enough detail for another contributor to reproduce it.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened?
+      placeholder: A concise description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: What exact steps reproduce the problem?
+      placeholder: |
+        1. Go to ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include versions, OS, runtime, browser, or commit SHA as needed.
+      placeholder: OS, version, runtime, commit, and any relevant configuration
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Logs, screenshots, related issues, or anything else that helps.

--- a/config/claudius/skills/setup-repository-baseline/assets/feature_request.yml.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/feature_request.yml.template
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Propose an improvement or new capability.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please explain the user or maintainer problem first.
+        Good feature requests describe the need before the implementation idea.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem are you trying to solve?
+      placeholder: Describe the gap or pain point.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Change
+      description: What should the project do differently?
+      placeholder: Describe the preferred outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other options did you consider?
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Links, prior art, constraints, or rollout concerns.

--- a/config/claudius/skills/setup-repository-baseline/assets/pull_request_template.md.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/pull_request_template.md.template
@@ -1,0 +1,24 @@
+# Pull Request
+
+## Summary
+
+Describe the intent of this change in a few sentences.
+
+## Changes
+
+- Describe the main code, documentation, or configuration changes.
+
+## Verification
+
+- List the commands, tests, or manual checks you ran.
+
+## Risks
+
+- Note rollout, migration, compatibility, or operational risks.
+
+## Checklist
+
+- [ ] Tests or validation steps were updated or run as needed
+- [ ] Documentation was updated when contributor or user behavior changed
+- [ ] `CHANGELOG.md` was updated when the change is release-note-worthy
+- [ ] Breaking changes, migrations, or security impact are called out

--- a/config/claudius/skills/setup-repository-baseline/assets/release.md.template
+++ b/config/claudius/skills/setup-repository-baseline/assets/release.md.template
@@ -1,0 +1,32 @@
+# Release Runbook
+
+This runbook describes the minimum release process for `__REPOSITORY_NAME__`.
+
+## Preconditions
+
+- `__DEFAULT_BRANCH__` is green and review-complete
+- `CHANGELOG.md` is updated
+- version metadata is updated if this repository tracks versions in files
+- release notes reflect the shipped change set
+
+## Release Steps
+
+1. Update the local default branch and verify the exact commit to release.
+2. Create a signed annotated tag such as `vX.Y.Z`.
+3. Push the tag to the remote.
+4. Publish a GitHub release using the changelog as the source of truth.
+5. Verify any published artifacts, packages, or installation paths.
+
+## Post-Release Checks
+
+- confirm the tag and release notes are visible remotely
+- confirm the installation or upgrade path works as expected
+- note any follow-up fixes for the next patch release
+
+## Rollback Thinking
+
+If a severe regression or security issue is discovered after release, document:
+
+- whether the release should be yanked or superseded
+- what mitigation is available immediately
+- how affected users should recover

--- a/config/claudius/skills/setup-repository-baseline/instructions.md
+++ b/config/claudius/skills/setup-repository-baseline/instructions.md
@@ -1,0 +1,195 @@
+# Setup Repository Baseline
+
+Establish the source-of-truth repository policy surface for a modern
+collaborative OSS repository before adding hosted enforcement or local hook
+automation.
+
+**The argument `$ARGUMENTS` is optional** and may provide
+`<primary-owner>[,<security-contact>]`.
+
+If `$ARGUMENTS` is omitted:
+
+- infer the repository name from the current directory or git remote
+- infer the default branch from `origin/HEAD` when possible, otherwise assume
+  `main`
+- infer the primary owner from the GitHub remote when possible
+- ask the user only for values that cannot be inferred safely
+
+Do NOT invent email addresses, team handles, or support URLs. If
+`security-contact` cannot be inferred from existing repository metadata, ask the
+user before creating `SECURITY.md`.
+
+## Goal
+
+Create or fill gaps in the following baseline files:
+
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `CHANGELOG.md`
+- `docs/runbooks/release.md`
+- `.github/CODEOWNERS`
+- `.github/pull_request_template.md`
+- `.github/ISSUE_TEMPLATE/bug_report.yml`
+- `.github/ISSUE_TEMPLATE/feature_request.yml`
+
+## Principles
+
+- Repository documents are the primary source of truth.
+- Hosted enforcement belongs in `/setup-github-guardrails`, not here.
+- Local hooks and developer feedback loops belong in `/setup-local-quality-loop`,
+  not here.
+- Keep policy concise, contributor-readable, and stack-agnostic.
+- Preserve existing project-specific content. Merge missing sections instead of
+  overwriting files wholesale.
+
+## Steps
+
+### 1. Inspect repository state
+
+Determine these values before editing:
+
+- repository name
+- default branch
+- primary owner for `CODEOWNERS`
+- security contact for `SECURITY.md`
+
+Inspect existing files first. If any of the target files already exist, preserve
+project-specific details and only fill gaps.
+
+Prefer these inference paths:
+
+1. existing repository files
+2. git remote metadata
+3. current directory name
+4. user confirmation
+
+For `CODEOWNERS`, a GitHub team handle is preferred for organization-owned
+repositories. If only a single maintainer handle is known, use that as the
+fallback owner.
+
+### 2. Create or update `CONTRIBUTING.md`
+
+If `CONTRIBUTING.md` does not exist, create it from
+[CONTRIBUTING.md.template](assets/CONTRIBUTING.md.template).
+
+If it already exists, ensure it covers these baseline policies:
+
+- how to propose changes and discuss larger changes early
+- branch-from-default-branch workflow
+- preference for small, reviewable pull requests
+- expectation to update tests, docs, and changelog when behavior changes
+- pull request title guidance as the canonical change summary
+- review etiquette and self-review expectations
+
+Do NOT hard-code language-specific commands or local tooling instructions here.
+The file should remain valid whether the repository uses Nix, pre-commit,
+lefthook, plain scripts, or no local automation.
+
+### 3. Create or update `SECURITY.md`
+
+If `SECURITY.md` does not exist, create it from
+[SECURITY.md.template](assets/SECURITY.md.template).
+
+If it already exists, ensure it includes:
+
+- a clear non-public reporting path
+- supported versions or branches
+- requested report contents
+- coordinated disclosure expectations
+
+Default policy for a new repository:
+
+- the default branch is supported
+- older releases are unsupported unless the repository already maintains them
+
+Do NOT leave placeholder contact values in the final file.
+
+### 4. Create or update `CHANGELOG.md`
+
+If `CHANGELOG.md` does not exist, create it from
+[CHANGELOG.md.template](assets/CHANGELOG.md.template).
+
+If it already exists, ensure there is an `Unreleased` section and that the file
+is appropriate for contributor-facing release notes.
+
+Prefer Keep a Changelog structure unless the repository already has another
+clear changelog convention.
+
+### 5. Create or update the release runbook
+
+If `docs/runbooks/release.md` does not exist, create it from
+[release.md.template](assets/release.md.template).
+
+If it already exists, ensure it covers:
+
+- release preconditions
+- changelog and version preparation
+- signed annotated tag creation
+- publishing a GitHub release
+- post-release verification and rollback thinking
+
+Keep the runbook process-oriented. Do NOT embed CI implementation details or
+service-specific deployment steps unless the repository already requires them.
+
+### 6. Create or update GitHub collaboration templates
+
+#### `.github/CODEOWNERS`
+
+If the file does not exist, create it from
+[CODEOWNERS.template](assets/CODEOWNERS.template).
+
+If it exists:
+
+- preserve granular path ownership rules
+- ensure there is a fallback owner entry for `*`
+- avoid removing stricter existing ownership patterns
+
+#### `.github/pull_request_template.md`
+
+If the file does not exist, create it from
+[pull_request_template.md.template](assets/pull_request_template.md.template).
+
+If it exists, ensure it asks for:
+
+- summary
+- verification
+- risk or rollout notes
+- documentation or changelog updates
+
+#### Issue templates
+
+Create these only when equivalent files do not already exist:
+
+- `.github/ISSUE_TEMPLATE/bug_report.yml` from
+  [bug_report.yml.template](assets/bug_report.yml.template)
+- `.github/ISSUE_TEMPLATE/feature_request.yml` from
+  [feature_request.yml.template](assets/feature_request.yml.template)
+
+If the repository already has issue forms, merge missing fields rather than
+duplicating templates under different names.
+
+Do NOT create `.github/ISSUE_TEMPLATE/config.yml` unless the repository already
+uses one or the user provides the required contact links and issue-routing
+policy.
+
+### 7. Finish cleanly
+
+Summarize:
+
+- which files were created
+- which files were updated
+- which values were inferred
+- which follow-up steps remain for hosted enforcement or local tooling
+
+If the repository still lacks CI, branch protection, PR-title lint, release
+automation, or local hooks, recommend `/setup-github-guardrails` and
+`/setup-local-quality-loop` as the next skills.
+
+## Important Notes
+
+- This skill defines policy and contributor workflow, not enforcement.
+- Prefer PR title policy and changelog discipline over heavy commit-local rules
+  when the repository uses squash merge.
+- Keep documents short and durable. Avoid stack-specific implementation details.
+- This skill must be idempotent. Running it multiple times must not create
+  duplicate templates or wipe existing repository-specific guidance.

--- a/config/claudius/skills/setup-repository-baseline/skill.yaml
+++ b/config/claudius/skills/setup-repository-baseline/skill.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: setup-repository-baseline
+description: >-
+  Establish repository governance documents and collaboration templates for a
+  modern OSS project: CONTRIBUTING.md, SECURITY.md, CHANGELOG.md, release
+  runbook, CODEOWNERS, and GitHub issue/PR templates. Use before CI or local
+  hook automation.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[optional: "<primary-owner>[,<security-contact>]"]'
+  codex:
+    invocation: manual


### PR DESCRIPTION
## Summary
- add `setup-repository-baseline` as the first primary shared setup skill
- include durable templates for CONTRIBUTING, SECURITY, CHANGELOG, release runbook, CODEOWNERS, and GitHub issue / PR templates
- register the implementation status in `catalog.yaml`, `inventory.yaml`, and `roadmap.md`

## Stack
- base branch: `chore/skills-inventory-roadmap`
- rebase onto `main` after the inventory PR merges

## Verification
- `nix develop --impure --command yamllint config/claudius/skills/catalog.yaml config/claudius/skills/inventory.yaml config/claudius/skills/setup-repository-baseline/skill.yaml config/claudius/skills/setup-repository-baseline/assets/bug_report.yml.template config/claudius/skills/setup-repository-baseline/assets/feature_request.yml.template`
- `nix develop --impure --command markdownlint config/claudius/skills/roadmap.md config/claudius/skills/setup-repository-baseline/instructions.md config/claudius/skills/setup-repository-baseline/assets/CONTRIBUTING.md.template config/claudius/skills/setup-repository-baseline/assets/SECURITY.md.template config/claudius/skills/setup-repository-baseline/assets/CHANGELOG.md.template config/claudius/skills/setup-repository-baseline/assets/release.md.template config/claudius/skills/setup-repository-baseline/assets/pull_request_template.md.template`
- `nix flake check`
