### PR TITLE
fix(flake): align home-manager with nixpkgs and bump claudius

### DIFF
--- a/config/home-manager/programs/vscode/default.nix
+++ b/config/home-manager/programs/vscode/default.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   lib,
-  home-manager,
   ...
 }:
 
@@ -9,7 +8,6 @@ let
   extensions = import ./extensions.nix;
   settings = import ./settings.nix { inherit pkgs; };
   metadata = import ./metadata.nix;
-  mkVscodeModule = import "${home-manager}/modules/programs/vscode/mkVscodeModule.nix";
 
   inherit (pkgs.stdenv.hostPlatform) system;
 
@@ -90,21 +88,8 @@ let
   });
 in
 {
-  imports = [
-    (mkVscodeModule {
-      modulePath = [
-        "programs"
-        "vscodeInsiders"
-      ];
-      name = "Visual Studio Code - Insiders";
-      packageName = "vscode";
-      nameShort = "Code - Insiders";
-      dataFolderName = ".vscode-insiders";
-    })
-  ];
-
   config = {
-    programs.vscodeInsiders = {
+    programs.vscode = {
       enable = true;
       mutableExtensionsDir = false;
       package = vscodeInsidersPackage;

--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777942337,
-        "narHash": "sha256-JLwE0HDIymshrbdbbcdqGc33s4kqMn0ZLCVr70mI2qc=",
+        "lastModified": 1777947758,
+        "narHash": "sha256-nQ0oRkNCPzSPT4BcU1uZZrTcAkIYY9dLu6mRDQHtO3Q=",
         "owner": "cariandrum22",
         "repo": "claudius",
-        "rev": "41bf4db24eca52f76df99e9713e94e20d11235bc",
+        "rev": "042abdc691835567cac43600ab927a508bbbc802",
         "type": "github"
       },
       "original": {
@@ -141,15 +141,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1777852249,
-        "narHash": "sha256-XdbGWnFlX4McOEG5NioVsp35Ic6XL/rXnp8as71cu6o=",
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c909892de502b4de9e92838a503c09a9c8ebe4aa",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Summary
- bump the Claudius flake input to `v0.2.3`
- align `home-manager` with `nixpkgs/nixos-25.11` by tracking `release-25.11`
- stop importing Home Manager internal VSCode module internals and use the public `programs.vscode` module with the custom insiders package

## Why
`home-manager` on `master` now imports `pkgs.path + "/lib/services/lib.nix"`, but this repo pins `nixpkgs` to `nixos-25.11`, where that path does not exist. That broke `nix flake check` and Home Manager evaluation while trying to take in Claudius `v0.2.3`.

The previous VSCode config also depended on `home-manager/modules/programs/vscode/mkVscodeModule.nix`, which is no longer present on `release-25.11`. The standard `programs.vscode` module already recognizes `pname = "vscode-insiders"`, so we can drop the internal import entirely.

This is the safe replacement for the earlier failed follow-up attempt.

## Verification
- `nix flake check --show-trace`
