### PR TITLE
feat(home-manager): add gh and SSM session plugin

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -21,6 +21,7 @@
         atuin
         zoxide
         carapace
+        gh
         ghq
         fzf
         (callPackage ./rivendell.nix { inherit pkgs; })
@@ -69,6 +70,7 @@
         powershell
         certbot
         awscli2
+        ssm-session-manager-plugin
         eksctl
         google-cloud-sdk
         k6


### PR DESCRIPTION
## Summary
- add `gh` to Home Manager packages
- add `ssm-session-manager-plugin` to Home Manager packages
- keep these user-scoped CLI tools out of the system profile

## Verification
- `nix eval` confirmed `gh` and `ssm-session-manager-plugin` are present in `home.packages`
- `nix run --impure .#switch`
- `command -v gh`
- `session-manager-plugin --version`
