### PR TITLE
feat(skills): add polyglot repository quality profiles

### DIFF
--- a/config/claudius/skills/setup-commitlint/instructions.md
+++ b/config/claudius/skills/setup-commitlint/instructions.md
@@ -3,9 +3,16 @@
 Set up commitlint with robust Conventional Commits rules, local git hooks, and
 CI enforcement.
 
-**The argument `$ARGUMENTS` is a comma-separated list of allowed scopes** for
-this project (e.g. `api,web,ci,deps,docs,nix,scripts,tooling`). If no argument
-is given, ask the user for the list of scopes.
+**The argument `$ARGUMENTS` is optional** and may provide a comma-separated list
+of desired scopes for this project (e.g.
+`api,web,ci,deps,docs,nix,scripts,tooling`).
+
+If `$ARGUMENTS` is omitted, infer and optimize the scope taxonomy from the
+existing repository structure and any existing `commitlint.config.cjs`.
+
+Read
+[references/scope-taxonomy.md](references/scope-taxonomy.md)
+before deriving the final scope list.
 
 ## Prerequisites
 
@@ -17,14 +24,61 @@ is given, ask the user for the list of scopes.
 
 ## Steps
 
-### 1. Create `commitlint.config.cjs`
+### 1. Determine the optimized scope taxonomy
 
-Create the file in the project root using the template in
+Build the final scope list before writing any files.
+
+If `commitlint.config.cjs` already exists, read its current `scope-enum` first
+and treat it as the continuity baseline.
+
+Then inspect the repository for stable collaboration surfaces, including:
+
+- top-level directories such as `apps/`, `packages/`, `crates/`, `modules/`,
+  `envs/`, `docs/`, `scripts/`, `infra/`, `tests/`
+- workspace manifests and package boundaries
+- workflow names and job structure under `.github/workflows/`
+- release, security, verification, or compliance subtrees that represent real
+  owned domains
+
+Derive scopes using these rules:
+
+- prefer stable logical domains, not every leaf directory
+- prefer lower-case hyphenated names
+- preserve existing useful scopes to avoid unnecessary churn
+- remove stale scopes that no longer map to real repository areas
+- merge over-granular scopes into a broader domain when individual areas are
+  not independently owned or reviewed
+- keep canonical shared scopes when the repository clearly has those concerns:
+  `ci`, `deps`, `docs`, `docker`, `nix`, `release`, `scripts`, `security`,
+  `tooling`, `config`, `tests`, `infra`
+- add domain scopes only when they are durable repo surfaces, such as `api`,
+  `web`, `server`, `client`, `addon`, `ffi`, `jose`, `verification`, `fstar`,
+  `tamarin`, or `kani`
+
+If `$ARGUMENTS` is provided, treat it as the desired baseline, then:
+
+- normalize spelling and duplicates
+- warn or prune clearly stale scopes
+- add missing shared scopes only when the repository structure makes the omission
+  clearly harmful
+
+Prefer a lean taxonomy. A good scope list is broad enough to remain stable over
+time and narrow enough to help routing, review, and release notes.
+
+### 2. Create or update `commitlint.config.cjs`
+
+Create or update the file in the project root using the template in
 [commitlint.config.cjs.template](assets/commitlint.config.cjs.template).
-Replace `__SCOPES__` with the scopes from the argument formatted as the
-JavaScript array entries.
+Replace `__SCOPES__` with the optimized scopes formatted as JavaScript array
+entries.
 
-### 2. Create `scripts/commitlint-pre-push.sh`
+If the file already exists:
+
+- preserve the current non-scope rules unless they are weaker than the template
+- update only the scope list and any clearly missing baseline rules
+- preserve scope ordering where possible to reduce needless diff churn
+
+### 3. Create `scripts/commitlint-pre-push.sh`
 
 Create the file using the template in
 [commitlint-pre-push.sh.template](assets/commitlint-pre-push.sh.template). Make
@@ -32,7 +86,7 @@ it executable (`chmod +x`).
 
 Create the `scripts/` directory if it does not exist.
 
-### 3. Add commitlint hooks to `flake.nix`
+### 4. Add commitlint hooks to `flake.nix`
 
 Add the following two hooks inside the `hooks = { ... }` block in `flake.nix`:
 
@@ -46,7 +100,7 @@ commitlint-pre-push =
 Do NOT duplicate if they already exist. If they exist in a different style
 (e.g. inline script), replace them with the above.
 
-### 4. Add CI workflow steps
+### 5. Add CI workflow steps
 
 If `.github/workflows/lint.yml` exists, add the commit message linting steps
 below. If a different lint workflow exists, add them there. If no lint workflow
@@ -62,8 +116,11 @@ from the template.
 
 ## Important Notes
 
-- Scopes are project-specific and reflect the project's directory structure or
-  logical areas.
+- Scopes are project-specific and should reflect stable repository domains, not
+  transient implementation details.
 - The `scope-empty` rule is set to `[0]` (disabled) so that scopes are
   optional.
 - Do NOT modify any existing CI steps; only add the commit lint steps.
+- Prefer continuity over churn. If a repository already has a good scope
+  taxonomy, optimize it incrementally rather than renaming everything at once.
+- Prefer omitting a low-signal scope over adding a noisy or unstable one.

--- a/config/claudius/skills/setup-commitlint/references/scope-taxonomy.md
+++ b/config/claudius/skills/setup-commitlint/references/scope-taxonomy.md
@@ -1,0 +1,147 @@
+# Scope Taxonomy
+
+Use this reference when deriving or optimizing the `scope-enum` for
+`commitlint.config.cjs`.
+
+## What Good Scopes Look Like
+
+A good commit scope is:
+
+- stable across time
+- small enough to fit naturally in a commit or PR title
+- aligned with a real ownership or review boundary
+- lower-case and preferably hyphenated
+- about a domain or surface, not a one-off implementation detail
+
+Good examples:
+
+- `api`
+- `web`
+- `server`
+- `client`
+- `ci`
+- `docs`
+- `deps`
+- `infra`
+- `security`
+- `verification`
+
+Weak examples:
+
+- `src`
+- `misc`
+- `temp`
+- `cleanup`
+- `bugfix`
+- `feature-x`
+- a single ephemeral file name
+
+## Inference Order
+
+When no explicit scope list is provided, infer scopes in this order:
+
+1. existing `commitlint.config.cjs`
+2. stable top-level repository structure
+3. workspace boundaries (`apps/*`, `packages/*`, `crates/*`, `modules/*`,
+   `envs/*`)
+4. persistent cross-cutting domains (`docs`, `ci`, `scripts`, `security`,
+   `release`, `tests`, `infra`, `verification`)
+5. current workflow structure and release boundaries
+
+Earlier sources should usually win unless they are clearly stale.
+
+## Optimization Rules
+
+### Preserve continuity
+
+If the repo already has a useful scope list, preserve it unless:
+
+- a scope no longer maps to any real repository area
+- a scope is so broad that it communicates nothing
+- several scopes should be merged into a clearer stable domain
+
+Avoid churn just because a different name could also work.
+
+### Keep shared concerns canonical
+
+When these areas exist, prefer these names:
+
+- `ci`
+- `deps`
+- `docs`
+- `docker`
+- `nix`
+- `release`
+- `scripts`
+- `security`
+- `tooling`
+- `config`
+- `tests`
+- `infra`
+
+### Add domain scopes only for durable surfaces
+
+Examples:
+
+- app monorepo: `api`, `web`, `addon`, `contracts`
+- Rust platform: `server`, `client`, `ffi`, `jose`, `verification`
+- infra repo: `envs`, `modules`
+
+Do not create one scope per tiny directory unless those directories are truly
+independent collaboration surfaces.
+
+### Merge over-granular taxonomies
+
+If the candidate list becomes too noisy:
+
+- merge sibling implementation areas into a broader product surface
+- keep a package or crate name only when it is independently owned, released, or
+  reviewed
+- collapse low-signal technical buckets into `tooling`, `scripts`, `config`, or
+  `infra` where appropriate
+
+### Prefer omission to noise
+
+Because `scope-empty` is optional, a repository does not need a scope for every
+possible change. If a candidate scope would be used rarely and communicates
+little, leave it out.
+
+## Repository Patterns
+
+### App or product monorepo
+
+Usually keep a mix of:
+
+- shared concerns: `ci`, `deps`, `docs`, `nix`, `scripts`, `tooling`
+- user-facing or service-facing surfaces: `api`, `web`, `server`, `client`,
+  `addon`
+- protocol or contract surfaces when they are first-class: `contracts`,
+  `verification`
+
+### Infrastructure repo
+
+Usually keep:
+
+- `ci`, `deps`, `docs`, `envs`, `modules`, `nix`, `scripts`, `security`,
+  `tooling`
+
+### Rust or verification-heavy monorepo
+
+Usually keep:
+
+- shared concerns: `ci`, `deps`, `docs`, `nix`, `scripts`, `security`, `tests`,
+  `tooling`
+- runtime or crate surfaces: `server`, `client`, `ffi`, `jose`
+- verification surfaces when they are true top-level domains: `verification`,
+  `proofs`, `fstar`, `tamarin`, `kani`
+
+## Final Check
+
+Before writing the config, ask:
+
+- would a maintainer understand this scope without opening the diff?
+- will this scope still make sense six months from now?
+- does this scope map to a real owned domain?
+- is the list concise enough to be learned by contributors?
+
+If the answer to any of these is no, simplify the taxonomy.

--- a/config/claudius/skills/setup-commitlint/skill.yaml
+++ b/config/claudius/skills/setup-commitlint/skill.yaml
@@ -2,11 +2,12 @@ version: 1
 name: setup-commitlint
 description: >-
   Set up commitlint with Conventional Commits rules, git hooks (commit-msg +
-  pre-push), and GitHub Actions CI. Use when adding commit message linting to a
-  project.
+  pre-push), and GitHub Actions CI. Can infer and optimize the allowed scope
+  taxonomy from an existing repository layout when no explicit scope list is
+  provided.
 targets:
   claude-code:
     invocation: manual
-    argument-hint: '[comma-separated scopes, e.g. "api,web,ci,deps,docs,nix,scripts,tooling"]'
+    argument-hint: '[optional: comma-separated scopes, e.g. "api,web,ci,deps,docs,nix,scripts,tooling"]'
   codex:
     invocation: manual

--- a/config/claudius/skills/setup-github-guardrails/instructions.md
+++ b/config/claudius/skills/setup-github-guardrails/instructions.md
@@ -1,0 +1,109 @@
+# Setup GitHub Guardrails
+
+Align GitHub-hosted workflow policy with a shared quality profile.
+
+**The argument `$ARGUMENTS` is required** and must be one of:
+
+- `rails-monorepo`
+- `tofu-infra`
+- `polyglot-oss`
+
+## Profile References
+
+Read the matching quality-profile reference before editing:
+
+- `rails-monorepo`:
+  [../setup-quality-profile/references/rails-monorepo.md](../setup-quality-profile/references/rails-monorepo.md)
+- `tofu-infra`:
+  [../setup-quality-profile/references/tofu-infra.md](../setup-quality-profile/references/tofu-infra.md)
+- `polyglot-oss`:
+  [../setup-quality-profile/references/polyglot-oss.md](../setup-quality-profile/references/polyglot-oss.md)
+
+Extract:
+
+- workflow naming rules
+- job display-name rules
+- step naming rules
+- stable required-check names
+- profile-specific permission expectations
+
+## Steps
+
+### 1. Inspect the current GitHub surface
+
+Inspect:
+
+- `.github/workflows/*.yml`
+- `.github/CODEOWNERS`
+- pull-request templates
+- whether commitlint already enforces PR titles
+
+Do NOT overwrite unrelated workflows wholesale. Normalize them incrementally.
+
+### 2. Normalize workflow names
+
+Use these patterns:
+
+- `CI - <Purpose>` for validation workflows
+- `Deploy - <Target>` for delivery workflows
+- `Release - <Target>` for publication workflows
+
+Avoid bare names such as `CI`, `Checks`, `Build`, or `Deploy`.
+
+### 3. Normalize job and step names
+
+For jobs that surface as required checks:
+
+- add or keep a stable human-readable `name:`
+- avoid names that encode temporary implementation detail
+
+For steps:
+
+- use `Verb + target`
+- add path qualifiers in parentheses when the repo has multiple app surfaces
+- prefer names that still make sense when viewed in the Actions UI without reading the YAML
+
+### 4. Keep permissions minimal
+
+Default to:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Add broader permissions only when a workflow actually needs them, for example `id-token: write` for
+OIDC-based cloud access.
+
+### 5. Preserve the lint policy surface
+
+Ensure the repo-wide lint workflow keeps:
+
+- `fetch-depth: 0`
+- commitlint range checks
+- PR-title lint when commitlint is present
+- stable job names that can be required in branch protection
+
+### 6. Recommend or apply branch protection carefully
+
+If the user explicitly asks for hosted enforcement and `gh` is available and authenticated,
+configure branch protection only after listing the exact checks that will be required.
+
+Otherwise, summarize the recommended required checks and leave the hosted settings unchanged.
+
+### 7. Finish cleanly
+
+Summarize:
+
+- which workflow names changed
+- which job names changed
+- which checks should be required
+- whether hosted branch-protection settings were only documented or also applied
+
+## Important Notes
+
+- Workflow and job names are part of the repository contract. Changing them can break
+  branch-protection rules and required-check configuration.
+- Prefer a few stable workflows over many overlapping ones.
+- This skill handles hosted GitHub policy. Use `/setup-local-quality-loop` for local hooks and
+  shared lint CI generation.

--- a/config/claudius/skills/setup-github-guardrails/skill.yaml
+++ b/config/claudius/skills/setup-github-guardrails/skill.yaml
@@ -1,0 +1,13 @@
+version: 1
+name: setup-github-guardrails
+description: >-
+  Align GitHub-hosted guardrails with a shared repository profile: workflow and
+  job naming, PR-title lint, minimal permissions, and optional branch
+  protection recommendations. Supported profiles: rails-monorepo, tofu-infra,
+  and polyglot-oss.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[rails-monorepo|tofu-infra|polyglot-oss]'
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-haskell-lint/assets/.hlint.yaml.template
+++ b/config/claudius/skills/setup-haskell-lint/assets/.hlint.yaml.template
@@ -1,0 +1,3 @@
+- group: {name: future, enabled: true}
+- group: {name: generalise, enabled: true}
+- group: {name: generalise-for-conciseness, enabled: true}

--- a/config/claudius/skills/setup-haskell-lint/assets/haskell-strict-check.sh.template
+++ b/config/claudius/skills/setup-haskell-lint/assets/haskell-strict-check.sh.template
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eu
+
+build_tool="${HASKELL_BUILD_TOOL:-auto}"
+strict_ghc_options="${HASKELL_STRICT_GHC_OPTIONS:--Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Werror}"
+
+detect_build_tool() {
+  if [ "$build_tool" != "auto" ]; then
+    printf '%s\n' "$build_tool"
+    return
+  fi
+
+  if [ -f stack.yaml ]; then
+    printf '%s\n' stack
+    return
+  fi
+
+  if ls ./*.cabal >/dev/null 2>&1 || [ -f cabal.project ]; then
+    printf '%s\n' cabal
+    return
+  fi
+
+  echo "Unable to detect a Haskell build tool. Set HASKELL_BUILD_TOOL=cabal or stack." >&2
+  exit 1
+}
+
+tool="$(detect_build_tool)"
+
+case "$tool" in
+  cabal)
+    cabal build all --ghc-options="$strict_ghc_options"
+    ;;
+  stack)
+    stack build --ghc-options "$strict_ghc_options"
+    ;;
+  *)
+    echo "Unsupported Haskell build tool: $tool" >&2
+    exit 1
+    ;;
+esac

--- a/config/claudius/skills/setup-haskell-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-haskell-lint/assets/hooks.nix.template
@@ -1,0 +1,3 @@
+fourmolu-check = mkHook "fourmolu-check" "fourmolu --mode check .";
+hlint-check = mkHook "hlint-check" "hlint .";
+haskell-strict-check = mkHook "haskell-strict-check" "./scripts/haskell-strict-check.sh";

--- a/config/claudius/skills/setup-haskell-lint/assets/pre-commit-hooks.yaml.template
+++ b/config/claudius/skills/setup-haskell-lint/assets/pre-commit-hooks.yaml.template
@@ -1,0 +1,17 @@
+- repo: local
+  hooks:
+    - id: fourmolu-check
+      name: fourmolu --mode check
+      entry: fourmolu --mode check .
+      language: system
+      pass_filenames: false
+    - id: hlint-check
+      name: hlint
+      entry: hlint .
+      language: system
+      pass_filenames: false
+    - id: haskell-strict-check
+      name: strict Haskell build
+      entry: ./scripts/haskell-strict-check.sh
+      language: system
+      pass_filenames: false

--- a/config/claudius/skills/setup-haskell-lint/instructions.md
+++ b/config/claudius/skills/setup-haskell-lint/instructions.md
@@ -1,0 +1,131 @@
+# Setup Haskell Lint
+
+Add Fourmolu, HLint, and a strict compile check for a Haskell project. This
+skill standardizes on check-only formatting, text linting, and a build step
+that treats warnings as errors.
+
+**The argument `$ARGUMENTS` is optional** and may provide `build_tool=cabal`,
+`build_tool=stack`, or `build_tool=auto` (default).
+
+## Prerequisites
+
+- The project must have Haskell package metadata such as a `.cabal` file,
+  `cabal.project`, or `stack.yaml`.
+- `fourmolu`, `hlint`, and the chosen build tool must be available.
+- For Nix Flake projects: ensure the dev shell exposes `fourmolu`, `hlint`, and
+  the chosen build tool.
+- For non-Nix projects: tell the user to install the missing tools. Do NOT run
+  installation commands automatically.
+
+## Steps
+
+### 1. Determine hook integration method
+
+Check whether `flake.nix` exists in the project root and already contains a
+`git-hooks` or `pre-commit-hooks` input.
+
+- If yes: follow Path A (Nix `git-hooks.nix`).
+- If no: follow Path B (pre-commit local hooks).
+
+Do NOT apply both paths.
+
+---
+
+### Path A: Nix git-hooks.nix
+
+#### A-1. Add hooks to `flake.nix`
+
+Add the hooks from [hooks.nix.template](assets/hooks.nix.template) into the
+`hooks = { ... }` block inside `git-hooks.lib.${system}.run`. Do NOT duplicate
+hooks that already exist.
+
+Hooks added:
+
+- `fourmolu-check` - runs `fourmolu --mode check .`
+- `hlint-check` - runs `hlint .`
+- `haskell-strict-check` - runs the strict build script
+
+#### A-2. Ensure tooling is in the dev shell
+
+Verify `fourmolu`, `hlint`, and the chosen build tool are available in the dev
+shell. Preserve existing package-management patterns if the project already has
+one.
+
+---
+
+### Path B: Pre-commit local hooks
+
+#### B-1. Add hooks to `.pre-commit-config.yaml`
+
+If `.pre-commit-config.yaml` does not exist, create it.
+
+Add the hooks from
+[pre-commit-hooks.yaml.template](assets/pre-commit-hooks.yaml.template) to the
+`repos` list. Do NOT duplicate hooks that already exist.
+
+Hooks added:
+
+- `fourmolu-check` - runs `fourmolu --mode check .`
+- `hlint-check` - runs `hlint .`
+- `haskell-strict-check` - runs the strict build script
+
+### 2. Create or update `.hlint.yaml`
+
+If `.hlint.yaml` does not exist, create it from
+[.hlint.yaml.template](assets/.hlint.yaml.template).
+
+If the file already exists, preserve the current project-specific hints and add
+only missing baseline groups:
+
+- `future`
+- `generalise`
+- `generalise-for-conciseness`
+
+Do NOT overwrite existing ignores or project-specific restrictions.
+
+### 3. Create `scripts/haskell-strict-check.sh`
+
+Create `scripts/haskell-strict-check.sh` from
+[haskell-strict-check.sh.template](assets/haskell-strict-check.sh.template) and
+make it executable.
+
+The script:
+
+- auto-detects `cabal` or `stack` unless overridden
+- applies strict GHC warning flags
+- treats warnings as errors at hook and CI time
+
+### 4. Inspect persistent warning policy
+
+Inspect `.cabal`, `cabal.project`, `package.yaml`, or `stack.yaml`.
+
+If the repository already persists strict warning flags in package metadata,
+preserve them.
+
+If it does not, inform the user that the hook and CI surface still enforce a
+strict build and recommend persisting the warning policy in project metadata
+later if they want local `build` commands to match the same strictness.
+
+### 5. Validate
+
+Run the following commands, or tell the user to run them:
+
+1. `fourmolu --mode check .`
+2. `hlint .`
+3. `./scripts/haskell-strict-check.sh`
+
+If formatting fails, tell the user to run `fourmolu -i` manually and review the
+diff.
+
+If HLint or the strict build fails, fix the code or narrow project-specific
+exceptions deliberately. Do NOT add broad ignore rules just to silence the
+baseline.
+
+## Important Notes
+
+- Do NOT use `fourmolu -i` or `hlint --refactor` inside hooks or CI.
+- Prefer Fourmolu defaults. Do NOT create `fourmolu.yaml` unless the repository
+  has a documented reason to diverge.
+- The strict build script is meant to expose warning debt. If a generated or
+  vendored subtree is noisy, narrow the scope of the build target rather than
+  weakening the global warning set.

--- a/config/claudius/skills/setup-haskell-lint/skill.yaml
+++ b/config/claudius/skills/setup-haskell-lint/skill.yaml
@@ -1,0 +1,11 @@
+version: 1
+name: setup-haskell-lint
+description: >-
+  Set up Fourmolu, HLint, and a strict Haskell build check with check-only
+  hooks. Use when adding Haskell formatting and lint gates.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[build_tool=auto|cabal|stack]'
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-lean-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-lean-lint/assets/hooks.nix.template
@@ -1,0 +1,1 @@
+lean-lint = mkHook "lean-lint" "./scripts/lean-lint-check.sh";

--- a/config/claudius/skills/setup-lean-lint/assets/lean-lint-check.sh.template
+++ b/config/claudius/skills/setup-lean-lint/assets/lean-lint-check.sh.template
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eu
+
+scope="${LEAN_LINT_SCOPE:-clippy}"
+
+lake build
+
+case "$scope" in
+  default)
+    lake lint
+    ;;
+  clippy)
+    lake lint --clippy
+    ;;
+  all)
+    lake lint --lint-all
+    ;;
+  *)
+    echo "Unsupported LEAN_LINT_SCOPE: $scope" >&2
+    exit 1
+    ;;
+esac

--- a/config/claudius/skills/setup-lean-lint/assets/pre-commit-hooks.yaml.template
+++ b/config/claudius/skills/setup-lean-lint/assets/pre-commit-hooks.yaml.template
@@ -1,0 +1,7 @@
+- repo: local
+  hooks:
+    - id: lean-lint
+      name: lean lint
+      entry: ./scripts/lean-lint-check.sh
+      language: system
+      pass_filenames: false

--- a/config/claudius/skills/setup-lean-lint/instructions.md
+++ b/config/claudius/skills/setup-lean-lint/instructions.md
@@ -1,0 +1,100 @@
+# Setup Lean Lint
+
+Add Lean quality checks for a Lake project. This skill standardizes on
+`lake build` plus `lake lint`, using the built-in Clippy-style linters by
+default. Keep the formatting surface project-specific and check-only.
+
+## Prerequisites
+
+- The project must have `lean-toolchain`.
+- The project must have `lakefile.lean` or `lakefile.toml`.
+- `lake` must be available in the environment.
+- For Nix Flake projects: ensure the Lean toolchain is available from the dev
+  shell or via an existing `elan`-managed workflow.
+- For non-Nix projects: tell the user to install the Lean toolchain with their
+  existing workflow. Do NOT run installation commands automatically.
+
+## Steps
+
+### 1. Determine hook integration method
+
+Check whether `flake.nix` exists in the project root and already contains a
+`git-hooks` or `pre-commit-hooks` input.
+
+- If yes: follow Path A (Nix `git-hooks.nix`).
+- If no: follow Path B (pre-commit local hooks).
+
+Do NOT apply both paths.
+
+---
+
+### Path A: Nix git-hooks.nix
+
+#### A-1. Add hooks to `flake.nix`
+
+Add the hook from [hooks.nix.template](assets/hooks.nix.template) into the
+`hooks = { ... }` block inside `git-hooks.lib.${system}.run`. Do NOT duplicate
+if it already exists.
+
+Hook added:
+
+- `lean-lint` - runs the shared Lean quality script
+
+---
+
+### Path B: Pre-commit local hooks
+
+#### B-1. Add hooks to `.pre-commit-config.yaml`
+
+If `.pre-commit-config.yaml` does not exist, create it.
+
+Add the hook from
+[pre-commit-hooks.yaml.template](assets/pre-commit-hooks.yaml.template) to the
+`repos` list. Do NOT duplicate if it already exists.
+
+Hook added:
+
+- `lean-lint` - runs the shared Lean quality script
+
+### 2. Create `scripts/lean-lint-check.sh`
+
+Create `scripts/lean-lint-check.sh` from
+[lean-lint-check.sh.template](assets/lean-lint-check.sh.template) and make it
+executable.
+
+The script:
+
+- runs `lake build`
+- runs `lake lint --clippy` by default
+- supports `LEAN_LINT_SCOPE=default|clippy|all` to adjust the built-in linter
+  scope
+
+### 3. Inspect the project's strictness surface
+
+Inspect `lakefile.lean` or `lakefile.toml`.
+
+- If the project centralizes shared `leanOptions`, prefer `autoImplicit = false`
+  or the equivalent project-wide option there instead of scattering
+  file-local exceptions.
+- Preserve any existing `lintDriver`, `builtinLint?`, or custom `lean_exe`
+  linters. Do NOT replace a stronger repository-specific lint surface.
+- If the project already exposes a checked formatter command, keep it under a
+  separate stable hook name such as `lean-format`.
+
+### 4. Validate
+
+Run the following commands, or tell the user to run them:
+
+1. `lake build`
+2. `./scripts/lean-lint-check.sh`
+
+If lint fails, fix the code or project lint configuration. Do NOT weaken the
+built-in linter scope globally just to get the hook green.
+
+## Important Notes
+
+- Do NOT invent an auto-format hook that rewrites files during commit.
+- Keep formatting editor- or project-command driven unless the repository
+  already has a checked formatter surface.
+- Use `LEAN_LINT_SCOPE=all` only when the project is already ready for the
+  broader lint set; `clippy` is the strict default for general Lean projects.

--- a/config/claudius/skills/setup-lean-lint/skill.yaml
+++ b/config/claudius/skills/setup-lean-lint/skill.yaml
@@ -1,0 +1,10 @@
+version: 1
+name: setup-lean-lint
+description: >-
+  Set up lake build and strict lake lint checks for a Lean 4 Lake project with
+  check-only hooks. Use when adding Lean quality gates.
+targets:
+  claude-code:
+    invocation: manual
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-local-quality-loop/instructions.md
+++ b/config/claudius/skills/setup-local-quality-loop/instructions.md
@@ -1,0 +1,123 @@
+# Setup Local Quality Loop
+
+Establish a fast local-and-CI feedback loop for a Nix-based repository without inventing a new
+project-specific policy surface.
+
+**The argument `$ARGUMENTS` is required** and must be one of:
+
+- `rails-monorepo`
+- `tofu-infra`
+- `polyglot-oss`
+
+## Profile References
+
+Read the matching quality-profile reference before editing:
+
+- `rails-monorepo`:
+  [../setup-quality-profile/references/rails-monorepo.md](../setup-quality-profile/references/rails-monorepo.md)
+- `tofu-infra`:
+  [../setup-quality-profile/references/tofu-infra.md](../setup-quality-profile/references/tofu-infra.md)
+- `polyglot-oss`:
+  [../setup-quality-profile/references/polyglot-oss.md](../setup-quality-profile/references/polyglot-oss.md)
+
+Extract:
+
+- the allowed commitlint scopes
+- the expected `CI - Lint` naming surface
+- the preferred hook names
+- any profile-specific CI initialization or skip rules
+
+## Steps
+
+### 1. Establish the shared Nix hook foundation
+
+Apply these component skills in order:
+
+1. `/setup-git-hooks`
+2. `/setup-nix-lint`
+3. `/setup-shell-lint`
+4. `/setup-file-hygiene`
+5. `/setup-secrets-scan`
+
+If the repository does not contain a root `flake.nix`, stop and tell the user that this skill
+expects a Nix-flake project.
+
+### 2. Add profile-specific local hook packs
+
+#### `rails-monorepo`
+
+The shared foundation is the mandatory baseline.
+
+Do NOT force `/setup-biome` automatically. Frontend or extension surfaces that need Vue, GraphQL,
+browser-extension, security, or functional linting should be handled by
+`/setup-typed-eslint-monorepo` and should keep domain-oriented root hook names as described in the
+profile reference.
+
+#### `tofu-infra`
+
+Add these component skills before generating CI:
+
+1. `/setup-tofu-lint`
+2. `/setup-iac-security`
+
+#### `polyglot-oss`
+
+The shared foundation is the mandatory baseline.
+
+Do NOT force language-specific hook packs from this skill. For polyglot
+repositories, apply the language skills later from `/setup-quality-profile`
+after scanning the repository surface:
+
+- `/setup-rust-lint`
+- `/setup-haskell-lint`
+- `/setup-lean-lint`
+- `/setup-python-lint`
+- `/setup-ruby-lint`
+- `/setup-ts-typecheck`
+- `/setup-biome`
+- `/setup-typed-eslint-monorepo`
+
+When normalizing hook names, prefer the stable language-surface names from the
+profile reference unless the repository already has a stronger domain-oriented
+surface.
+
+### 3. Add commitlint with the profile scopes
+
+For `rails-monorepo` and `tofu-infra`, run `/setup-commitlint` with the exact
+scope list from the profile reference.
+
+For `polyglot-oss`, run `/setup-commitlint` without explicit scopes so it can
+infer the repository taxonomy, then preserve the shared baseline scopes from
+the profile reference and trim anything that does not map to a real durable
+domain in the target repository.
+
+### 4. Generate the repo-wide lint workflow
+
+Run `/setup-nix-ci-lint` after all hooks are in place.
+
+### 5. Normalize the naming surface
+
+After generation, ensure the local and CI surface matches the profile:
+
+- repo-wide lint workflow name is `CI - Lint`
+- required jobs have stable human-readable `name:` values
+- commitlint and PR-title lint run after `pre-commit`
+- dependency installation happens before `pre-commit`
+- `fetch-depth: 0` is preserved
+- `SKIP` is used only for profile-approved hooks and documented inline
+
+### 6. Finish cleanly
+
+Summarize:
+
+- which hooks were added
+- which commit scopes were used
+- whether any hook names were normalized
+- which CI steps still need repository-specific commands
+
+## Important Notes
+
+- This skill establishes the shared feedback loop. Stack-specific application or platform skills
+  should be layered on top by `/setup-quality-profile`.
+- Keep root hook names stable even if the underlying command changes.
+- Do NOT silently drop commitlint or PR-title lint from the lint workflow.

--- a/config/claudius/skills/setup-local-quality-loop/skill.yaml
+++ b/config/claudius/skills/setup-local-quality-loop/skill.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: setup-local-quality-loop
+description: >-
+  Establish a shared local quality loop for a Nix-based repository by composing
+  git-hooks.nix, shared lint and secrets hooks, commitlint, and repo-wide lint
+  CI. Supported profiles: rails-monorepo, tofu-infra, and polyglot-oss.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[rails-monorepo|tofu-infra|polyglot-oss]'
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-nix-ci-lint/assets/lint.yml.template
+++ b/config/claudius/skills/setup-nix-ci-lint/assets/lint.yml.template
@@ -1,4 +1,4 @@
-name: Lint
+name: CI - Lint
 
 on:
   pull_request:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/config/claudius/skills/setup-quality-profile/instructions.md
+++ b/config/claudius/skills/setup-quality-profile/instructions.md
@@ -1,0 +1,140 @@
+# Setup Quality Profile
+
+Apply a shared quality profile by composing the existing repository-baseline, local-quality-loop,
+and GitHub-guardrails layers with profile-specific stack guidance.
+
+**The argument `$ARGUMENTS` is required** and must begin with one of:
+
+- `rails-monorepo`
+- `tofu-infra`
+- `polyglot-oss`
+
+An optional suffix may provide `<primary-owner>[,<security-contact>]`, for example:
+
+- `rails-monorepo,@example/platform,@example/security`
+- `tofu-infra,@example/infrastructure`
+- `polyglot-oss,@example/maintainers,@example/security`
+
+## Profile References
+
+Read the matching profile reference before changing anything:
+
+- `rails-monorepo`: [references/rails-monorepo.md](references/rails-monorepo.md)
+- `tofu-infra`: [references/tofu-infra.md](references/tofu-infra.md)
+- `polyglot-oss`: [references/polyglot-oss.md](references/polyglot-oss.md)
+
+Extract these values from the reference:
+
+- commitlint scope taxonomy
+- workflow, job, and step naming conventions
+- stable required check names
+- stack-specific linting expectations
+- acceptable CI skip rules
+
+## Steps
+
+### 1. Confirm the profile fits the repository
+
+Inspect the repository layout before editing.
+
+Use `rails-monorepo` when the repository has a Rails API plus other app or package surfaces under a
+shared root.
+
+Use `tofu-infra` when the repository primarily manages Terraform or OpenTofu code, typically with
+`envs/` and `modules/` or similar directories.
+
+Use `polyglot-oss` when the repository mixes one or more general-purpose
+language surfaces such as Rust, Haskell, Lean, Python, Ruby, or TypeScript and
+does not clearly fit the Rails-monorepo or OpenTofu-infra archetypes.
+
+If the repository does not clearly fit any profile, stop and tell the user
+which assumptions failed.
+
+### 2. Apply the repository policy baseline
+
+Run `/setup-repository-baseline` first.
+
+Pass through any inferred or user-provided owner and security-contact values so the baseline
+documents, `CODEOWNERS`, and templates match the profile rollout.
+
+### 3. Apply the shared local quality loop
+
+Run `/setup-local-quality-loop <profile>`.
+
+This establishes the shared Nix hook foundation, commitlint, repo-wide lint CI, and the stable
+naming surface for the core `CI - Lint` workflow.
+
+### 4. Add profile-specific stack guardrails
+
+#### `rails-monorepo`
+
+Run `/setup-rails-api`.
+
+Then run `/setup-typed-eslint-monorepo` for the frontend and package surfaces that need more than
+Biome.
+
+If the repo also has plain TypeScript packages without framework-specific linting needs, use
+`/setup-ts-typecheck` and optionally `/setup-biome` selectively for those simpler surfaces.
+
+#### `tofu-infra`
+
+The shared local quality loop already adds the core IaC hook pack for this profile.
+
+After it finishes, inspect for any repository-specific release or deployment scripts and keep their
+names aligned with the profile reference.
+
+#### `polyglot-oss`
+
+Inspect the repository before applying language skills. Do NOT blindly apply
+every language-specific skill.
+
+Apply the matching skills only for real surfaces:
+
+- Rust (`Cargo.toml`, `crates/`, or a Cargo workspace):
+  `/setup-rust-lint`
+- Haskell (`.cabal`, `cabal.project`, `stack.yaml`):
+  `/setup-haskell-lint`
+- Lean (`lean-toolchain` and `lakefile.lean` or `lakefile.toml`):
+  `/setup-lean-lint`
+- Python (`pyproject.toml`, `.python-version`, or clear Python package surface):
+  `/setup-python-lint`
+- Generic Ruby (`Gemfile` or `gems.rb`, outside Rails-monorepo scope):
+  `/setup-ruby-lint`
+- TypeScript:
+  use `/setup-typed-eslint-monorepo` for framework-heavy, browser-extension,
+  GraphQL, security-sensitive, or functional-rule-heavy surfaces; otherwise use
+  `/setup-ts-typecheck` and optionally `/setup-biome`
+
+If the Ruby surface also uses Sorbet, layer `/setup-sorbet` after
+`/setup-ruby-lint`.
+
+If the repository actually contains a Rails API plus additional app surfaces
+under one root, stop and switch to `rails-monorepo` instead of partially
+simulating it under `polyglot-oss`.
+
+### 5. Align the GitHub-hosted guardrails
+
+Run `/setup-github-guardrails <profile>`.
+
+This keeps workflow names, check names, PR-title enforcement, and optional branch-protection
+recommendations aligned with the same profile reference.
+
+### 6. Finish cleanly
+
+Summarize:
+
+- which component skills were applied
+- which commitlint scopes were used
+- which workflow and job names were created or normalized
+- which checks should be required in branch protection
+- any manual follow-up still needed for stack-specific linting
+
+## Important Notes
+
+- Profiles are opinionated starting points, not blind scaffolding.
+- Stable workflow and job names are part of the repository API because branch protection and merge
+  policy depend on them.
+- Keep commit scopes aligned to the repository taxonomy. Remove stale scopes when a domain does not
+  exist in the target repository.
+- Prefer a shared repo-wide lint workflow plus a small number of stack-specific workflows over many
+  overlapping checks.

--- a/config/claudius/skills/setup-quality-profile/references/polyglot-oss.md
+++ b/config/claudius/skills/setup-quality-profile/references/polyglot-oss.md
@@ -1,0 +1,173 @@
+# Polyglot OSS Quality Profile
+
+Use this profile for a repository that mixes one or more general-purpose
+language surfaces such as Rust, Haskell, Lean, Python, Ruby, and TypeScript
+without clearly fitting the existing Rails-monorepo or OpenTofu-infra
+archetypes.
+
+## Commit Scope Taxonomy
+
+Keep the scope taxonomy small and durable.
+
+Shared baseline scopes:
+
+- `ci`
+- `config`
+- `deps`
+- `docs`
+- `nix`
+- `release`
+- `scripts`
+- `security`
+- `tests`
+- `tooling`
+
+Add durable repository domains only when they represent clear ownership
+surfaces, for example:
+
+- `api`
+- `cli`
+- `compiler`
+- `core`
+- `crates`
+- `packages`
+- `parser`
+- `proofs`
+- `runtime`
+- `sdk`
+- `web`
+
+Do NOT default to language names as commit scopes unless the repository really
+uses language-segmented top-level ownership such as `rust/`, `python/`, or
+`lean/`.
+
+## Workflow Naming
+
+Preferred workflow display names:
+
+- `CI - Lint` for repo-wide policy and low-cost validation
+- `CI - Rust`
+- `CI - Haskell`
+- `CI - Lean`
+- `CI - Python`
+- `CI - Ruby`
+- `CI - TypeScript`
+- `Deploy - <Target>`
+- `Release - <Target>`
+
+Avoid generic names such as `CI`, `Checks`, `Build`, or `Deploy`.
+
+## Job Naming
+
+Prefer stable human-readable job `name:` fields for checks that may become
+required:
+
+- `Lint`
+- `Rust Lint`
+- `Haskell Lint`
+- `Lean Lint`
+- `Python Lint`
+- `Ruby Lint`
+- `TypeScript Lint`
+
+Keep the display name stable even if the underlying command changes.
+
+## Step Naming
+
+Use `Verb + target` naming. Add path qualifiers when there are multiple app or
+package surfaces.
+
+Good examples:
+
+- `Install Rust dependencies`
+- `Run Haskell format checks`
+- `Run Lean builtin lint`
+- `Run Python type checks`
+- `Install web dependencies (packages/web)`
+- `Lint PR title`
+
+Avoid generic steps such as `Setup`, `Run script`, or `Checks`.
+
+## Local Hook Naming
+
+Preferred hook names:
+
+- `rust-lint`
+- `haskell-lint`
+- `lean-lint`
+- `python-lint`
+- `ruby-lint`
+- `ts-lint`
+- `ts-typecheck`
+- `commitlint`
+- `commitlint-pre-push`
+
+Use stronger domain-oriented hook names only when the repository already has a
+clear surface contract that is better than language-level naming.
+
+## Linter Policy
+
+### Rust
+
+The Rust baseline should include:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets --all-features`
+- `-D warnings`
+- `clippy::pedantic`
+- `clippy::cargo`
+- explicit denials for `unwrap`, `expect`, `panic`, `todo`, and `unimplemented`
+
+### Haskell
+
+The Haskell baseline should include:
+
+- `fourmolu --mode check .`
+- `hlint .`
+- a strict build with `-Wall`, `-Wcompat`, and warnings treated as errors
+
+### Lean
+
+The Lean baseline should include:
+
+- `lake build`
+- `lake lint --clippy` by default
+- preservation of project-specific lint drivers or custom Lake lint executables
+
+Formatting stays project-specific unless the repository already exposes a
+checked formatter command.
+
+### Python
+
+Use `/setup-python-lint`.
+
+### Ruby
+
+Use `/setup-ruby-lint` for general Ruby surfaces.
+
+If the repository also uses typed Ruby, layer `/setup-sorbet` on top.
+
+### TypeScript
+
+For plain TS and JS packages, prefer `/setup-ts-typecheck` and `/setup-biome`.
+
+For framework-heavy, browser-extension, GraphQL, security-sensitive, or
+functional-rule-heavy surfaces, prefer `/setup-typed-eslint-monorepo`.
+
+## CI Policy
+
+- Use `fetch-depth: 0` in lint workflows.
+- Install language dependencies before running `pre-commit`.
+- Keep commitlint and PR-title lint in the repo-wide `CI - Lint` workflow.
+- Keep hooks and CI check-only.
+- Split language-specific workflows only when their dependency boot cost or run
+  time justifies a dedicated surface.
+
+## Required Checks
+
+Typical minimum:
+
+- `CI - Lint / Lint`
+
+Add language-specific checks to branch protection only when they are stable,
+always-on, and clearly owned by the repository.

--- a/config/claudius/skills/setup-quality-profile/references/rails-monorepo.md
+++ b/config/claudius/skills/setup-quality-profile/references/rails-monorepo.md
@@ -1,0 +1,134 @@
+# Rails Monorepo Quality Profile
+
+Use this profile for a repository that has a Rails API plus one or more additional app surfaces such
+as a web frontend, browser add-on, contracts, or shared packages under a single root.
+
+## Commit Scope Taxonomy
+
+Recommended `scope-enum` values:
+
+- `addon`
+- `api`
+- `auth`
+- `ci`
+- `compose`
+- `config`
+- `contracts`
+- `deps`
+- `docker`
+- `docs`
+- `nix`
+- `packages`
+- `scripts`
+- `share-links`
+- `tooling`
+- `web`
+
+Keep only the scopes that match real repository domains. Do NOT keep a scope for a path or concern
+that does not exist.
+
+## Workflow Naming
+
+Use GitHub Actions workflow display names as a stable public interface.
+
+Preferred names:
+
+- `CI - Lint` for the repo-wide static-analysis and policy workflow
+- `CI - Rails` for backend-only Rails checks when split from the repo-wide lint
+- `CI - Web` or `CI - Add-on` for app-specific workflows when they exist
+- `Deploy - API`, `Deploy - Web`, `Deploy - Add-on` for delivery workflows
+- `Release - <Target>` only for versioning or publication flows
+
+Avoid bare names such as `CI`, `Checks`, `Build`, or `Deploy`.
+
+## Job Naming
+
+Prefer explicit human-readable job `name:` fields for all checks that may be required by branch
+protection.
+
+Preferred display names:
+
+- `Lint`
+- `Ruby Scan`
+- `Web Lint`
+- `Add-on Lint`
+- `Contract Checks`
+
+Keep job IDs machine-oriented if desired, but keep the display name stable.
+
+## Step Naming
+
+Use `Verb + target` as the default pattern. Add a path qualifier in parentheses when the repository
+has multiple apps.
+
+Good examples:
+
+- `Install Ruby gems (apps/api)`
+- `Install web dependencies (apps/web)`
+- `Audit web dependencies (apps/web)`
+- `Build API image for Dockle`
+- `Contract checks (pull_request)`
+- `Lint PR title`
+
+Avoid generic steps such as `Setup`, `Run script`, or `Checks`.
+
+## Local Hook Naming
+
+Prefer stable root hook names by domain:
+
+- `ruby-lint`
+- `web-lint`
+- `addon-lint`
+- `shell-lint`
+- `docker-lint`
+- `commitlint`
+- `commitlint-pre-push`
+
+Use domain names rather than tool names when the hook validates a whole app surface. This keeps the
+hook stable if the command behind it changes.
+
+## Linter Policy
+
+### Backend
+
+The backend baseline should include:
+
+- RuboCop with Rails, performance, rake, minitest, and thread-safety plugins
+- Sorbet when the repo uses static typing
+- Brakeman
+- bundler-audit
+- Zeitwerk validation when it is a Rails application
+
+### Frontend and Packages
+
+Do NOT default to Biome for every JS or TS surface.
+
+Prefer typed ESLint when the repo needs any of the following:
+
+- Vue support
+- GraphQL linting
+- browser-extension surfaces
+- security plugins
+- functional-programming rules that Biome cannot express precisely
+
+Use `/setup-typed-eslint-monorepo` for those richer surfaces.
+
+Use Biome selectively for plain JS or TS packages that do not need those specialized checks.
+
+## CI Policy
+
+- Use `fetch-depth: 0` in lint workflows.
+- Install dependencies before running `pre-commit`.
+- Keep commitlint and PR-title lint in the repo-wide `CI - Lint` workflow.
+- Add repo-specific checks such as contract validation, Docker image scanning, or GraphQL validation
+  when the repository actually uses those surfaces.
+
+## Required Checks
+
+Keep required check names stable.
+
+Typical minimum:
+
+- `CI - Lint / Lint`
+
+Add stack-specific required checks only when they are durable and clearly owned.

--- a/config/claudius/skills/setup-quality-profile/references/tofu-infra.md
+++ b/config/claudius/skills/setup-quality-profile/references/tofu-infra.md
@@ -1,0 +1,105 @@
+# OpenTofu Infrastructure Quality Profile
+
+Use this profile for a repository that primarily manages Terraform or OpenTofu code, typically with
+environment directories and reusable modules.
+
+## Commit Scope Taxonomy
+
+Recommended `scope-enum` values:
+
+- `ci`
+- `deps`
+- `docs`
+- `envs`
+- `modules`
+- `nix`
+- `scripts`
+- `security`
+- `tooling`
+
+Keep the list small. Scopes should map to real repository domains, not every single cloud service or
+resource name.
+
+## Workflow Naming
+
+Preferred workflow display names:
+
+- `CI - Lint` for repo-wide linting and policy checks
+- `Deploy - <Environment>` for environment-specific apply or release workflows
+- `Release - Infrastructure` only if the repository versions release artifacts
+
+Avoid generic names such as `CI`, `Deploy`, or `Checks`.
+
+## Job Naming
+
+Prefer stable human-readable job `name:` fields:
+
+- `Lint`
+- `Plan`
+- `Apply`
+
+If a workflow only has one job, still set a job name explicitly so branch protection checks remain
+stable.
+
+## Step Naming
+
+Use `Verb + target` naming and be explicit about infrastructure tooling.
+
+Good examples:
+
+- `Initialize tflint plugins`
+- `Run pre-commit hooks`
+- `Lint commit messages (push)`
+- `Lint PR title`
+
+Avoid generic steps such as `Setup` or `Run checks`.
+
+## Local Hook Naming
+
+Preferred hook names:
+
+- `tofu-format`
+- `hclfmt`
+- `tflint`
+- `tofu-validate-no-backend`
+- `tfsec`
+- `trivy-config`
+- `shellcheck`
+- `shfmt`
+- `commitlint`
+- `commitlint-pre-push`
+
+Keep hook names aligned with the tool name when the repository surface is already singular and
+infrastructure-specific.
+
+## Linter and Security Policy
+
+The infrastructure baseline should include:
+
+- Nix linting for the flake
+- shellcheck and shfmt
+- file hygiene checks
+- secrets scanning
+- `tofu fmt`
+- `hclfmt`
+- `tflint`
+- `tofu-validate-no-backend`
+- `tfsec`
+- `trivy config`
+
+## CI Policy
+
+- Use `fetch-depth: 0` in lint workflows.
+- Run `tflint --init` before `pre-commit` when `tflint` is enabled.
+- Skip `tofu-validate-no-backend` in CI only when provider initialization is not feasible there.
+  When skipped, document the reason inline next to `SKIP`.
+- Keep commitlint and PR-title lint in the same `CI - Lint` workflow.
+
+## Required Checks
+
+Typical minimum:
+
+- `CI - Lint / Lint`
+
+Add plan or apply checks to branch protection only when they are stable, non-environmental, and
+expected for every pull request.

--- a/config/claudius/skills/setup-quality-profile/skill.yaml
+++ b/config/claudius/skills/setup-quality-profile/skill.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: setup-quality-profile
+description: >-
+  Apply a shared repository quality profile by composing baseline repository
+  policy, local hooks, lint CI, commitlint, and GitHub guardrails. Supported
+  profiles: rails-monorepo, tofu-infra, and polyglot-oss.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[profile][,<primary-owner>[,<security-contact>]]'
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-rails-ci/assets/ci.yml.template
+++ b/config/claudius/skills/setup-rails-ci/assets/ci.yml.template
@@ -1,4 +1,4 @@
-name: CI
+name: CI - Rails
 
 on:
   pull_request:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   scan_ruby:
+    name: Ruby Scan
     runs-on: ubuntu-latest
 
     steps:
@@ -22,6 +23,7 @@ jobs:
       # Security and consistency steps go here (see step 3)
 
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/config/claudius/skills/setup-repository-baseline/instructions.md
+++ b/config/claudius/skills/setup-repository-baseline/instructions.md
@@ -38,6 +38,8 @@ Create or fill gaps in the following baseline files:
 - Hosted enforcement belongs in `/setup-github-guardrails`, not here.
 - Local hooks and developer feedback loops belong in `/setup-local-quality-loop`,
   not here.
+- Use `/setup-quality-profile` when bootstrapping a repository to the shared
+  house style end to end.
 - Keep policy concise, contributor-readable, and stack-agnostic.
 - Preserve existing project-specific content. Merge missing sections instead of
   overwriting files wholesale.
@@ -182,8 +184,9 @@ Summarize:
 - which follow-up steps remain for hosted enforcement or local tooling
 
 If the repository still lacks CI, branch protection, PR-title lint, release
-automation, or local hooks, recommend `/setup-github-guardrails` and
-`/setup-local-quality-loop` as the next skills.
+automation, or local hooks, recommend `/setup-quality-profile` for a one-shot
+bootstrap or `/setup-github-guardrails` and `/setup-local-quality-loop`
+separately when the user wants finer control.
 
 ## Important Notes
 

--- a/config/claudius/skills/setup-ruby-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-ruby-lint/assets/hooks.nix.template
@@ -1,0 +1,1 @@
+ruby-lint = mkHook "ruby-lint" "bundle exec rubocop --parallel --format quiet";

--- a/config/claudius/skills/setup-ruby-lint/assets/pre-commit-hooks.yaml.template
+++ b/config/claudius/skills/setup-ruby-lint/assets/pre-commit-hooks.yaml.template
@@ -1,0 +1,8 @@
+- repo: local
+  hooks:
+    - id: ruby-lint
+      name: rubocop
+      entry: bundle exec rubocop --parallel --format quiet
+      language: system
+      files: \.rb$
+      pass_filenames: true

--- a/config/claudius/skills/setup-ruby-lint/assets/rubocop.yml.template
+++ b/config/claudius/skills/setup-ruby-lint/assets/rubocop.yml.template
@@ -1,0 +1,54 @@
+plugins:
+  - rubocop-performance
+  - rubocop-thread_safety
+__OPTIONAL_PLUGINS__
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: __RUBY_VERSION__
+  SuggestExtensions: false
+  Exclude:
+    - "bin/*"
+    - "vendor/**/*"
+    - "node_modules/**/*"
+    - "log/**/*"
+    - "tmp/**/*"
+
+Layout/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/AbcSize:
+  Max: 20
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
+Style/MutableConstant:
+  Enabled: true
+
+Style/GlobalVars:
+  Enabled: true
+
+Style/For:
+  Enabled: true
+
+Style/EachWithObject:
+  Enabled: true
+
+Style/CombinableLoops:
+  Enabled: true
+
+Style/GuardClause:
+  Enabled: true
+
+Lint/ConstantDefinitionInBlock:
+  Enabled: true

--- a/config/claudius/skills/setup-ruby-lint/instructions.md
+++ b/config/claudius/skills/setup-ruby-lint/instructions.md
@@ -1,0 +1,135 @@
+# Setup Ruby Lint
+
+Add generic RuboCop checks for a Ruby project. This skill standardizes on
+RuboCop with performance and thread-safety cops, plus optional Rake and
+Minitest support when the repository actually uses those surfaces.
+
+**The argument `$ARGUMENTS` is an optional Ruby target version** such as `3.3`.
+If it is omitted, infer it from `.ruby-version`, `.tool-versions`, `mise.toml`,
+`Gemfile`, or `gems.rb`. If it still cannot be inferred safely, ask the user.
+
+## Prerequisites
+
+- The project must have a root `Gemfile` or `gems.rb`.
+- `bundle exec` must work for the repository.
+- For Nix Flake projects: ensure the dev shell provides Ruby and Bundler, but
+  preserve any existing Bundler workflow.
+
+## Steps
+
+### 1. Detect optional plugin surfaces
+
+Inspect the repository before editing:
+
+- If it has a `Rakefile` or `.rake` files, add `rubocop-rake`.
+- If it already depends on Minitest or has a conventional `test/` tree, add
+  `rubocop-minitest`.
+
+Do NOT add Rails cops here. Rails-specific policy belongs in `/setup-rubocop`
+or `/setup-rails-api`.
+
+### 2. Add RuboCop gems to the development toolchain
+
+Add these gems to the `development, test` group in `Gemfile` if they are not
+already present:
+
+```ruby
+gem 'rubocop', require: false
+gem 'rubocop-performance', require: false
+gem 'rubocop-thread_safety', require: false
+```
+
+Add these only when the surface exists:
+
+```ruby
+gem 'rubocop-rake', require: false
+gem 'rubocop-minitest', require: false
+```
+
+Do NOT remove existing project-specific RuboCop plugins unless they are clearly
+obsolete and the user asked for cleanup.
+
+### 3. Create or update `.rubocop.yml`
+
+Create `.rubocop.yml` from [rubocop.yml.template](assets/rubocop.yml.template)
+if it does not exist.
+
+Replace:
+
+- `__RUBY_VERSION__`
+- `__OPTIONAL_PLUGINS__`
+
+If `.rubocop.yml` already exists, merge missing baseline rules and plugins
+without removing existing project-specific configuration.
+
+### 4. Create `bin/rubocop` wrapper (optional)
+
+If `bin/rubocop` does not exist, create it:
+
+```ruby
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+ARGV.unshift('--config', File.expand_path('../.rubocop.yml', __dir__))
+load Gem.bin_path('rubocop', 'rubocop')
+```
+
+Make it executable.
+
+### 5. Determine hook integration method
+
+Check whether `flake.nix` exists in the project root and already contains a
+`git-hooks` or `pre-commit-hooks` input.
+
+- If yes: follow Path A (Nix `git-hooks.nix`).
+- If no: follow Path B (pre-commit local hooks).
+
+Do NOT apply both paths.
+
+---
+
+### Path A: Nix git-hooks.nix
+
+#### A-1. Add hooks to `flake.nix`
+
+Add the hook from [hooks.nix.template](assets/hooks.nix.template) into the
+`hooks = { ... }` block inside `git-hooks.lib.${system}.run`. Do NOT duplicate
+if it already exists.
+
+Hook added:
+
+- `ruby-lint` - runs `bundle exec rubocop --parallel --format quiet`
+
+---
+
+### Path B: Pre-commit local hooks
+
+#### B-1. Add hooks to `.pre-commit-config.yaml`
+
+If `.pre-commit-config.yaml` does not exist, create it.
+
+Add the hook from
+[pre-commit-hooks.yaml.template](assets/pre-commit-hooks.yaml.template) to the
+`repos` list. Do NOT duplicate if it already exists.
+
+Hook added:
+
+- `ruby-lint` - runs `bundle exec rubocop --parallel --format quiet`
+
+### 6. Validate
+
+Run the following command, or tell the user to run it:
+
+1. `bundle exec rubocop --parallel`
+
+If the repository uses the generated `bin/rubocop` wrapper, `bundle exec
+bin/rubocop --parallel` is also acceptable.
+
+## Important Notes
+
+- Hooks and CI must stay check-only. Do NOT add `-A`, `-a`, or other
+  auto-correct flags to hooks.
+- Keep the generic Ruby policy separate from Rails policy. Use
+  `/setup-sorbet` when the repository also wants typed Ruby.
+- Prefer a small baseline plugin set plus narrow, explicit additions over a
+  large generic RuboCop stack.

--- a/config/claudius/skills/setup-ruby-lint/skill.yaml
+++ b/config/claudius/skills/setup-ruby-lint/skill.yaml
@@ -1,0 +1,11 @@
+version: 1
+name: setup-ruby-lint
+description: >-
+  Set up generic RuboCop checks for a Ruby project with check-only hooks. Use
+  when adding Ruby formatting and lint gates outside Rails-specific setups.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[ruby_version, e.g. "3.3"]'
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-rust-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-rust-lint/assets/hooks.nix.template
@@ -1,0 +1,3 @@
+cargo-fmt-check = mkHook "cargo-fmt-check" "bash -c 'cargo fmt --all -- --check'";
+cargo-clippy-strict =
+  mkHook "cargo-clippy-strict" "bash -c 'cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::cargo -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented'";

--- a/config/claudius/skills/setup-rust-lint/assets/pre-commit-hooks.yaml.template
+++ b/config/claudius/skills/setup-rust-lint/assets/pre-commit-hooks.yaml.template
@@ -1,0 +1,12 @@
+- repo: local
+  hooks:
+    - id: cargo-fmt-check
+      name: cargo fmt --check
+      entry: cargo fmt --all -- --check
+      language: system
+      pass_filenames: false
+    - id: cargo-clippy-strict
+      name: cargo clippy strict
+      entry: cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::cargo -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented
+      language: system
+      pass_filenames: false

--- a/config/claudius/skills/setup-rust-lint/instructions.md
+++ b/config/claudius/skills/setup-rust-lint/instructions.md
@@ -1,0 +1,95 @@
+# Setup Rust Lint
+
+Add `cargo fmt` and strict `cargo clippy` checks for a Cargo project. This
+skill standardizes on the community formatter and a strict Clippy gate with
+check-only hooks.
+
+## Prerequisites
+
+- The project must have a root `Cargo.toml`.
+- The active Rust toolchain must provide `cargo`, `rustfmt`, and `clippy`.
+- For Nix Flake projects: ensure the chosen Rust toolchain in
+  `devShells.default.packages` exposes the `rustfmt` and `clippy` components.
+- For non-Nix projects: if the components are missing, tell the user to run
+  `rustup component add rustfmt clippy`. Do NOT run it automatically.
+
+## Steps
+
+### 1. Determine hook integration method
+
+Check whether `flake.nix` exists in the project root and already contains a
+`git-hooks` or `pre-commit-hooks` input.
+
+- If yes: follow Path A (Nix `git-hooks.nix`).
+- If no: follow Path B (pre-commit local hooks).
+
+Do NOT apply both paths.
+
+---
+
+### Path A: Nix git-hooks.nix
+
+#### A-1. Add hooks to `flake.nix`
+
+Add the hooks from [hooks.nix.template](assets/hooks.nix.template) into the
+`hooks = { ... }` block inside `git-hooks.lib.${system}.run`. Do NOT duplicate
+hooks that already exist.
+
+Hooks added:
+
+- `cargo-fmt-check` - runs `cargo fmt --all -- --check`
+- `cargo-clippy-strict` - runs strict `cargo clippy` checks across the whole
+  workspace
+
+#### A-2. Ensure the Rust toolchain is in the dev shell
+
+Verify the project's dev shell provides `cargo`, `rustfmt`, and `clippy`. If
+the toolchain is already managed via overlays or `fenix`, preserve the existing
+pattern and only fill gaps.
+
+---
+
+### Path B: Pre-commit local hooks
+
+#### B-1. Add hooks to `.pre-commit-config.yaml`
+
+If `.pre-commit-config.yaml` does not exist, create it.
+
+Add the hooks from
+[pre-commit-hooks.yaml.template](assets/pre-commit-hooks.yaml.template) to the
+`repos` list. Do NOT duplicate hooks that already exist.
+
+Hooks added:
+
+- `cargo-fmt-check` - runs `cargo fmt --all -- --check`
+- `cargo-clippy-strict` - runs the strict Clippy gate for the workspace
+
+### 2. Preserve existing Clippy configuration
+
+If `clippy.toml` or `.clippy.toml` already exists, preserve it.
+
+Do NOT create a Clippy config file by default. Keep the baseline strictness
+explicit in hooks and CI so the policy remains visible and portable across
+toolchain managers.
+
+### 3. Validate
+
+Run the following commands, or tell the user to run them:
+
+1. `cargo fmt --all -- --check`
+2. `cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::cargo -D clippy::unwrap_used -D clippy::expect_used -D clippy::panic -D clippy::todo -D clippy::unimplemented`
+
+If `cargo fmt` reports formatting drift, tell the user to run `cargo fmt --all`
+manually and review the diff.
+
+If Clippy reports violations, keep the lint levels intact and fix the code. Do
+NOT add `#[allow]` attributes broadly just to make the hook pass.
+
+## Important Notes
+
+- Keep hooks and CI check-only. Do NOT add `cargo fmt` without `--check` or
+  `cargo clippy --fix` to hooks.
+- Prefer hook- or CI-level lint flags over crate-level `#![deny(...)]` changes
+  unless the repository explicitly wants source-local lint policy.
+- If a workspace is too large for one Clippy job, split the CI surface by
+  package or domain, but keep the same lint-level set everywhere.

--- a/config/claudius/skills/setup-rust-lint/skill.yaml
+++ b/config/claudius/skills/setup-rust-lint/skill.yaml
@@ -1,0 +1,10 @@
+version: 1
+name: setup-rust-lint
+description: >-
+  Set up cargo fmt and strict cargo clippy checks for a Cargo project with
+  check-only hooks. Use when adding Rust formatting and lint gates.
+targets:
+  claude-code:
+    invocation: manual
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-typed-eslint-monorepo/instructions.md
+++ b/config/claudius/skills/setup-typed-eslint-monorepo/instructions.md
@@ -1,0 +1,161 @@
+# Setup Typed ESLint Monorepo
+
+Set up or normalize typed ESLint for monorepo surfaces where Biome would lose
+important framework, security, or domain-specific checks.
+
+**The argument `$ARGUMENTS` is optional** and may provide a comma-separated list
+of target surfaces such as:
+
+- `web,addon`
+- `apps/web,apps/addon`
+- `apps/web,packages/graphql-types`
+
+If `$ARGUMENTS` is omitted, inspect the repository and infer the candidate
+surfaces.
+
+## References
+
+Read these before editing:
+
+- [../setup-quality-profile/references/rails-monorepo.md](../setup-quality-profile/references/rails-monorepo.md)
+- [references/surface-selection.md](references/surface-selection.md)
+- [references/rule-patterns.md](references/rule-patterns.md)
+
+Use the profile reference for naming and CI policy. Use the local references for
+ESLint-vs-Biome selection and surface-specific rule patterns.
+
+## Steps
+
+### 1. Identify the JS and TS surfaces
+
+Inspect likely monorepo roots such as:
+
+- `apps/*`
+- `packages/*`
+- other workspace directories referenced by `pnpm-workspace.yaml`,
+  `package.json`, or similar
+
+For each candidate surface, inspect:
+
+- `package.json`
+- `eslint.config.*` or `.eslintrc*`
+- `tsconfig*.json`
+- framework markers such as `vue`, browser extension manifests, GraphQL tooling,
+  or security-sensitive runtime code
+
+If `$ARGUMENTS` is present, restrict changes to that explicit surface list.
+
+### 2. Decide whether the surface should keep ESLint
+
+Keep or add typed ESLint when a surface needs one or more of:
+
+- Vue single-file component support
+- browser extension or mixed browser and Node runtime linting
+- GraphQL-aware lint scripts or document validation
+- `eslint-plugin-security`
+- `eslint-plugin-functional`
+- narrow file-pattern overrides for tests, stories, stores, scripts, or
+  generated code
+
+If a surface is plain JS or TS without those needs, do NOT force ESLint there.
+Recommend `/setup-biome` or keep the existing simpler stack instead.
+
+### 3. Normalize package-local scripts
+
+For each ESLint-managed surface, prefer package-local scripts such as:
+
+- `lint`
+- `typecheck`
+- `format:check`
+
+Keep or add auxiliary scripts only when the surface already needs them, for
+example:
+
+- `lint:graphql`
+- `lint:md`
+
+Use the framework-appropriate type checker:
+
+- Vue: prefer `vue-tsc`
+- plain TypeScript: `tsc --noEmit`
+
+Do NOT replace an existing stronger or more specific typecheck command.
+
+### 4. Normalize the ESLint config shape
+
+Prefer flat config (`eslint.config.*`) for new work.
+
+For each ESLint-managed surface:
+
+- use `typescript-eslint` typed configs
+- set `parserOptions.project` to the surface-local `tsconfig` files
+- set `tsconfigRootDir` correctly for the surface
+- keep ignores local to the surface build outputs and generated files
+
+Add framework or domain plugins only where justified:
+
+- Vue app: `eslint-plugin-vue` and `vue-eslint-parser`
+- browser or mixed runtime code: `eslint-plugin-security` when handling
+  untrusted inputs or filesystem or process boundaries
+- immutability-heavy UI or extension logic: `eslint-plugin-functional` with
+  targeted overrides
+
+Do NOT blindly copy the same ruleset to every surface. Match the rule pattern to
+the surface type.
+
+### 5. Keep overrides intentional and narrow
+
+When a rule is too strict for a subset of files, narrow it by path or file
+pattern rather than disabling it globally.
+
+Typical override targets:
+
+- `**/*.vue`
+- `**/*.test.*`
+- `**/*.spec.*`
+- `**/*.stories.*`
+- `**/stores/**/*.ts`
+- `scripts/**/*.mjs`
+- e2e or live-test directories
+
+Document the reason in the config only when the intent would otherwise be hard
+to infer.
+
+### 6. Integrate with root hooks and CI
+
+If the repository uses Nix root hooks, keep hook names domain-oriented:
+
+- `web-lint`
+- `addon-lint`
+- `packages-lint`
+
+Prefer hook commands that delegate to package scripts, for example:
+
+```nix
+web-lint = mkHook "web-lint" "bash -c 'cd apps/web && pnpm lint && pnpm typecheck && pnpm format:check'";
+```
+
+In CI:
+
+- install dependencies before running `pre-commit`
+- use explicit step names with path qualifiers
+- keep ESLint-managed surfaces separate from plain Biome-managed surfaces when
+  they have different dependency or framework needs
+
+### 7. Finish cleanly
+
+Summarize:
+
+- which surfaces stayed on typed ESLint
+- which surfaces should use Biome instead
+- which scripts were added or normalized
+- which root hooks or CI steps were added or renamed
+- any surface that still needs manual framework-specific lint commands
+
+## Important Notes
+
+- This skill is for monorepo surfaces that need ESLint because of framework or
+  domain complexity. It is not a blanket replacement for `/setup-biome`.
+- Prefer package-local lint entry points and root-level domain hooks.
+- When a surface already has a stronger typed ESLint setup, merge missing pieces
+  rather than rewriting the config wholesale.

--- a/config/claudius/skills/setup-typed-eslint-monorepo/references/rule-patterns.md
+++ b/config/claudius/skills/setup-typed-eslint-monorepo/references/rule-patterns.md
@@ -1,0 +1,60 @@
+# Rule Patterns
+
+Use these patterns when normalizing typed ESLint across monorepo surfaces.
+
+## Vue Web App
+
+Prefer:
+
+- `typescript-eslint` typed configs
+- `eslint-plugin-vue`
+- `vue-eslint-parser`
+- `eslint-plugin-security` when the app handles URLs, tokens, or untrusted input
+- `eslint-plugin-functional` only with narrow overrides
+
+Typical overrides:
+
+- disable some immutability rules in `**/*.vue`
+- relax strict unsafe rules in tests and stories
+- disable type-aware linting in Node-only scripts when appropriate
+
+Use `vue-tsc` for `typecheck` instead of raw `tsc`.
+
+## Browser Add-on
+
+Prefer:
+
+- typed `typescript-eslint`
+- `eslint-plugin-security`
+- `eslint-plugin-functional` when state mutation needs tight control
+
+Typical overrides:
+
+- allow conditional or expression statements where browser APIs require them
+- keep immutability rules strict in production code
+- relax rules only for tests or generated files
+
+Use explicit browser globals or extension runtime globals rather than broad
+global disables.
+
+## Plain TS Package
+
+If the package is plain TS without framework-specific needs, do not introduce a
+heavy ESLint stack just to mirror the app surfaces. Prefer Biome plus a
+typecheck command unless the package already depends on ESLint-specific rules.
+
+## Root Hook and CI Pattern
+
+Keep root hooks domain-oriented and delegate to package scripts:
+
+- `web-lint`
+- `addon-lint`
+
+Prefer CI step names such as:
+
+- `Install web dependencies (apps/web)`
+- `Install add-on dependencies (apps/addon)`
+- `Audit web dependencies (apps/web)`
+
+Avoid hook or step names that expose a temporary tool choice when the real owned
+surface is the domain.

--- a/config/claudius/skills/setup-typed-eslint-monorepo/references/surface-selection.md
+++ b/config/claudius/skills/setup-typed-eslint-monorepo/references/surface-selection.md
@@ -1,0 +1,40 @@
+# Surface Selection
+
+Use this reference to decide whether a monorepo surface should keep typed ESLint
+or can be simplified to Biome.
+
+## Keep Typed ESLint
+
+Typed ESLint is the better fit when a surface needs one or more of:
+
+- Vue single-file component linting
+- custom parsers such as `vue-eslint-parser`
+- browser extension runtime boundaries
+- `eslint-plugin-security`
+- `eslint-plugin-functional`
+- narrow path-based overrides by file class
+- GraphQL-aware lint scripts or markdown or docs lint scripts tightly coupled to
+  the package
+
+These are the common signs that a surface is not just formatting plus basic
+syntax lint.
+
+## Prefer Biome
+
+Biome is usually enough when the surface is:
+
+- plain TypeScript or JavaScript
+- not using Vue or another parser-dependent framework
+- not using security or functional lint plugins
+- not relying on many surface-specific override buckets
+- mainly looking for formatting, unused imports, and baseline correctness rules
+
+## Mixed Repositories
+
+It is normal for one repository to use both:
+
+- typed ESLint on `apps/web`
+- typed ESLint on `apps/addon`
+- Biome on simpler shared packages
+
+Do not force uniformity if it reduces useful signal.

--- a/config/claudius/skills/setup-typed-eslint-monorepo/skill.yaml
+++ b/config/claudius/skills/setup-typed-eslint-monorepo/skill.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: setup-typed-eslint-monorepo
+description: >-
+  Set up or normalize typed ESLint for monorepo app or package surfaces that
+  need more than Biome, such as Vue apps, browser add-ons, GraphQL-aware
+  packages, and surfaces that require security or functional lint plugins.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: '[optional: "web,addon,packages/foo"]'
+  codex:
+    invocation: manual


### PR DESCRIPTION
## Summary
- add reusable repository quality skills for GitHub guardrails, local quality loops, typed ESLint monorepos, and profile-driven rollout
- add polyglot lint rollout skills for Rust, Haskell, Lean, and generic Ruby
- tighten commitlint scope taxonomy guidance and align existing repository baseline templates
- cleanup of the legacy managed skill layout was split into #734

## Testing
- nix develop --impure -c pre-commit run --all-files
- nix flake check