### PR TITLE
chore(claudius): bump to v0.2.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1777947758,
-        "narHash": "sha256-nQ0oRkNCPzSPT4BcU1uZZrTcAkIYY9dLu6mRDQHtO3Q=",
+        "lastModified": 1778025366,
+        "narHash": "sha256-givBTY3QuwHPZkPAoJEqaxqpjfEVYly/U+cs+C9rjPI=",
         "owner": "cariandrum22",
         "repo": "claudius",
-        "rev": "042abdc691835567cac43600ab927a508bbbc802",
+        "rev": "f0406e369e86e8b694fc1c08545061de46d04d96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- update the pinned `claudius` flake input from `v0.2.3` to `v0.2.4`
- pull in `fix(skills): preserve Codex skill discoverability`
- pull in the accompanying CI hardening from upstream Claudius

## Verification
- `nix flake check`
- `nix run --impure .#switch`
- `claudius --version` -> `0.2.4`
- verified that `~/.agents/skills` contains 42 `SKILL.md` entries and `0` `agents/openai.yaml` overlays after switch
- verified in a fresh Codex session that the managed Claudius skills are visible again