### PR TITLE
feat(claudius): add figma desktop mcp

### DIFF
--- a/config/claudius/claude.settings.json
+++ b/config/claudius/claude.settings.json
@@ -84,6 +84,7 @@
       "mcp__awslabs_aws-documentation-mcp-server",
       "mcp__codex",
       "mcp__figma",
+      "mcp__figma-desktop",
       "mcp__chrome-devtools",
       "mcp__github",
       "mcp__google-calendar",

--- a/config/claudius/gemini.settings.json
+++ b/config/claudius/gemini.settings.json
@@ -67,6 +67,7 @@
       "awslabs_aws-documentation-mcp-server",
       "perplexity-ask",
       "figma",
+      "figma-desktop",
       "google-calendar",
       "notion",
       "todoist",

--- a/config/claudius/mcpServers.json
+++ b/config/claudius/mcpServers.json
@@ -36,6 +36,11 @@
       "command": "bash",
       "env": {}
     },
+    "figma-desktop": {
+      "args": [],
+      "env": {},
+      "url": "http://127.0.0.1:3845/mcp"
+    },
     "filesystem": {
       "args": [
         "-y",

--- a/config/claudius/settings.json
+++ b/config/claudius/settings.json
@@ -83,6 +83,7 @@
       "WebFetch(domain:*)",
       "mcp__awslabs_aws-documentation-mcp-server",
       "mcp__figma",
+      "mcp__figma-desktop",
       "mcp__chrome-devtools",
       "mcp__github",
       "mcp__google-calendar",

--- a/config/home-manager/programs/claudius.nix
+++ b/config/home-manager/programs/claudius.nix
@@ -14,17 +14,17 @@ let
   claudiusExe = lib.getExe' pkgs.claudius "claudius";
   jsonFormat = pkgs.formats.json { };
   baseMcpServers = builtins.fromJSON (builtins.readFile (claudiusSource + "/mcpServers.json"));
-  interactiveRemoteMcpServerNames = [
+  nonHeadlessMcpServerNames = [
     "figma"
+    "figma-desktop"
     "notion"
     "todoist"
   ];
-  # These hosted servers rely on browser-based OAuth, so do not publish them on headless hosts.
+  # These servers either need a local desktop app or browser-mediated
+  # authentication, so do not publish them on headless hosts.
   filteredMcpServers =
     if isHeadless then
-      lib.filterAttrs (
-        name: _: !(lib.elem name interactiveRemoteMcpServerNames)
-      ) baseMcpServers.mcpServers
+      lib.filterAttrs (name: _: !(lib.elem name nonHeadlessMcpServerNames)) baseMcpServers.mcpServers
     else
       baseMcpServers.mcpServers;
   playwrightArgs = [


### PR DESCRIPTION
## Summary
- add a `figma-desktop` MCP variant that targets the local Figma Desktop MCP endpoint
- expose the new MCP in Claude, Codex, and Gemini allow-lists
- treat `figma-desktop` as non-headless so Home Manager omits it on hosts without a local desktop app

## Testing
- `jq` validation for Claudius JSON files
- `nix build .#homeConfigurations.aarch64-darwin.activationPackage --impure --no-link`