### PR TITLE
fix(ai-tools): repair automated AI tool updates

### DIFF
--- a/config/home-manager/home/packages/claude-code.nix
+++ b/config/home-manager/home/packages/claude-code.nix
@@ -1,27 +1,50 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
-pkgs.stdenv.mkDerivation rec {
+let
   pname = "claude-code";
-  version = "2.1.100";
+  version = "2.1.143";
 
-  src = pkgs.fetchzip {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-${version}.tgz";
-    hash = "sha256-7/Rhk1z3Us2vOYGa85lkVIzzqdQFmfmAxrT39a7D27Y=";
+  sources = {
+    aarch64-darwin = {
+      url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-${version}.tgz";
+      hash = "sha256-XoZFAoRi/wxxeXhKvUdZHOI5nS/GWFe07PhfQrWM/Mc=";
+    };
+    x86_64-linux = {
+      url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-${version}.tgz";
+      hash = "sha256-OfXj8/M7VBCSRSXCbd+8sAbcFgC3Ehu5RvaY3plZqGA=";
+    };
   };
 
-  nativeBuildInputs = [ pkgs.makeWrapper ];
+  sourceInfo =
+    sources.${pkgs.stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${pkgs.stdenv.hostPlatform.system}");
+in
+pkgs.stdenv.mkDerivation rec {
+  inherit pname version;
+
+  src = pkgs.fetchzip {
+    inherit (sourceInfo) url hash;
+  };
+
+  nativeBuildInputs = [
+    pkgs.makeWrapper
+  ]
+  ++ lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+
+  buildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.stdenv.cc.cc.lib ];
 
   dontBuild = true;
+  dontStrip = true;
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/node_modules/@anthropic-ai/claude-code
-    cp -r . $out/lib/node_modules/@anthropic-ai/claude-code
+    mkdir -p $out/lib/${pname}
+    cp -r . $out/lib/${pname}
+    chmod +x $out/lib/${pname}/claude
 
     mkdir -p $out/bin
-    makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/claude \
-      --add-flags "$out/lib/node_modules/@anthropic-ai/claude-code/cli.js" \
+    makeWrapper $out/lib/${pname}/claude $out/bin/claude \
       --set CLAUDE_NO_AUTO_UPDATE 1
 
     runHook postInstall
@@ -33,11 +56,15 @@ pkgs.stdenv.mkDerivation rec {
     $out/bin/claude --version | grep -q "${version}"
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "Use Claude, Anthropic's AI assistant, right from your terminal";
     homepage = "https://github.com/anthropics/claude-code";
     license = licenses.unfree;
     maintainers = [ ];
     mainProgram = "claude";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
   };
 }

--- a/scripts/update-claude-code.py
+++ b/scripts/update-claude-code.py
@@ -1,46 +1,302 @@
 #!/usr/bin/env python3
-"""Update claude-code CLI tool using functional programming style.
+"""Update claude-code CLI package metadata.
 
-This script automatically updates the claude-code metadata used by Nix.
-It fetches the latest version from NPM and generates the appropriate hash.
-
-Usage:
-    ./update-claude-code.py
-
-Files modified:
-    config/home-manager/home/packages/default.nix
+Claude Code now publishes a thin npm wrapper plus platform-specific native
+packages. This updater tracks the wrapper version, but records hashes for the
+native packages that the Nix derivation actually installs.
 """
 
-import sys
-from pathlib import Path
+from __future__ import annotations
 
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import common
 import update_lib as lib
 
-# Configuration
-CONFIG = lib.UpdateConfig(
-    tool_name="claude-code",
-    nix_file=Path("config/home-manager/home/packages/claude-code.nix"),
-    version_pattern=r'(\s+version\s*=\s*")([^"]+)(")',
-    hash_pattern=r'(\s+hash\s*=\s*")([^"]+)(")',
+PACKAGE_NAME = "@anthropic-ai/claude-code"
+PLATFORM_PACKAGES: dict[str, str] = {
+    "aarch64-darwin": "@anthropic-ai/claude-code-darwin-arm64",
+    "x86_64-linux": "@anthropic-ai/claude-code-linux-x64",
+}
+
+RE_VERSION = re.compile(r'version\s*=\s*"([^"]+)";')
+RE_HASH_BLOCK = re.compile(
+    r"(  sources = \{\n)((?:    \w+(?:-\w+)* = \{.*?\};\n)+)(  \};)",
+    re.DOTALL | re.MULTILINE,
 )
 
-PACKAGE_NAME = "@anthropic-ai/claude-code"
+
+class ClaudeCodeConfigError(common.ConfigError):
+    """Error reading claude-code.nix configuration."""
 
 
-def main() -> int:
-    """Main entry point using functional pipeline."""
-    # Create the update pipeline
-    update_pipeline = lib.create_npm_update_pipeline(CONFIG, PACKAGE_NAME)
+class PlatformHash(NamedTuple):
+    """Hash information for a single platform."""
 
-    # Execute the pipeline
-    result = update_pipeline()
+    system: str
+    hash: str
 
-    # Display result
-    lib.print_result(result)
 
-    # Return appropriate exit code
-    return 0 if not result.error else 1
+def _claude_code_nix_path() -> Path:
+    return common.resolve_script_relative(
+        "..",
+        "config",
+        "home-manager",
+        "home",
+        "packages",
+        "claude-code.nix",
+    )
+
+
+def _fetch_registry() -> dict[str, object]:
+    return common.fetch_json(f"https://registry.npmjs.org/{PACKAGE_NAME}")
+
+
+def _fetch_registry_versions(package_name: str) -> set[str]:
+    response = common.fetch_json(f"https://registry.npmjs.org/{package_name}")
+    versions = response.get("versions")
+    if not isinstance(versions, dict) or not versions:
+        msg = f"Could not determine published versions for {package_name}"
+        raise ClaudeCodeConfigError(msg)
+    return set(versions.keys())
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    main, _, suffix = version.partition("-")
+    parts = tuple(int(part) for part in main.split("."))
+    if suffix:
+        return (*parts, -1)
+    return (*parts, 0)
+
+
+def _supported_versions_desc() -> tuple[str, list[str]]:
+    registry = _fetch_registry()
+    latest = registry.get("dist-tags", {}).get("latest")
+    versions = registry.get("versions")
+
+    if not isinstance(latest, str) or not latest:
+        msg = "Could not determine latest claude-code version"
+        raise ClaudeCodeConfigError(msg)
+
+    if not isinstance(versions, dict) or not versions:
+        msg = "Could not determine published claude-code versions"
+        raise ClaudeCodeConfigError(msg)
+
+    supported = set(versions.keys())
+    with ThreadPoolExecutor(max_workers=len(PLATFORM_PACKAGES)) as pool:
+        for package_versions in pool.map(
+            _fetch_registry_versions,
+            PLATFORM_PACKAGES.values(),
+        ):
+            supported &= package_versions
+
+    if not supported:
+        msg = (
+            "Could not find any claude-code version published for all "
+            "supported platforms"
+        )
+        raise ClaudeCodeConfigError(msg)
+
+    return latest, sorted(supported, key=_version_key, reverse=True)
+
+
+def _current_version_from_text(content: str) -> str:
+    if (match := RE_VERSION.search(content)) is None:
+        msg = "Could not find version in claude-code.nix"
+        raise ClaudeCodeConfigError(msg)
+    return match.group(1)
+
+
+def _current_hashes_from_text(content: str) -> dict[str, str]:
+    if (match := RE_HASH_BLOCK.search(content)) is None:
+        msg = "Could not find sources block in claude-code.nix"
+        raise ClaudeCodeConfigError(msg)
+
+    body = match.group(2)
+    hashes: dict[str, str] = {}
+    current_system: str | None = None
+
+    for line in body.splitlines():
+        if (
+            system_match := re.match(
+                r"^\s*([A-Za-z0-9_-]+)\s*=\s*\{$",
+                line,
+            )
+        ) is not None:
+            current_system = system_match.group(1)
+            continue
+
+        if current_system is None:
+            continue
+
+        if (hash_match := re.match(r'^\s*hash\s*=\s*"([^"]+)";$', line)) is not None:
+            hashes[current_system] = hash_match.group(1)
+            continue
+
+        if re.match(r"^\s*\};$", line) is not None:
+            current_system = None
+
+    return hashes
+
+
+def _tarball_basename(package_name: str) -> str:
+    return package_name.rsplit("/", maxsplit=1)[-1]
+
+
+def _download_url(version: str, system: str) -> str:
+    package_name = PLATFORM_PACKAGES[system]
+    tarball_name = _tarball_basename(package_name)
+    return (
+        f"https://registry.npmjs.org/{package_name}/-/"
+        f"{tarball_name}-{version}.tgz"
+    )
+
+
+def _prefetch_hash_for(version: str, system: str) -> PlatformHash:
+    url = _download_url(version, system)
+    try:
+        return PlatformHash(
+            system=system,
+            hash=str(lib.calculate_hash(url)),
+        )
+    except common.SubprocessError as exc:
+        msg = (
+            f"Failed to prefetch {system} package for claude-code "
+            f"{version}: {exc}"
+        )
+        raise ClaudeCodeConfigError(msg) from exc
+
+
+def _fetch_all_hashes(version: str) -> dict[str, str]:
+    with ThreadPoolExecutor(max_workers=len(PLATFORM_PACKAGES)) as pool:
+        results = list(
+            pool.map(
+                lambda system: _prefetch_hash_for(version, system),
+                PLATFORM_PACKAGES.keys(),
+            ),
+        )
+    return {result.system: result.hash for result in results}
+
+
+def _generate_hash_block(hashes: dict[str, str]) -> str:
+    lines: list[str] = []
+    for system in sorted(hashes.keys()):
+        package_name = PLATFORM_PACKAGES[system]
+        tarball_name = _tarball_basename(package_name)
+        lines.extend([
+            f"    {system} = {{",
+            f'      url = "https://registry.npmjs.org/{package_name}/-/{tarball_name}-${{version}}.tgz";',
+            f'      hash = "{hashes[system]}";',
+            "    };",
+        ])
+    return "\n".join(lines)
+
+
+def _update_nix_content(content: str, new_version: str, hashes: dict[str, str]) -> str:
+    content = RE_VERSION.sub(f'version = "{new_version}";', content)
+
+    hash_block = _generate_hash_block(hashes)
+    if RE_HASH_BLOCK.search(content):
+        return RE_HASH_BLOCK.sub(rf"\1{hash_block}\n\3", content)
+
+    msg = "Could not find hash block in claude-code.nix"
+    raise ClaudeCodeConfigError(msg)
+
+
+def _select_target_release(*, verbose: bool) -> tuple[str, str, dict[str, str]]:
+    wrapper_latest, candidate_versions = _supported_versions_desc()
+    prefetch_errors: list[str] = []
+
+    for version in candidate_versions:
+        if verbose:
+            print(f"\nFetching hashes for supported platforms ({version})...")
+
+        try:
+            hashes = _fetch_all_hashes(version)
+        except ClaudeCodeConfigError as exc:
+            prefetch_errors.append(str(exc))
+            continue
+
+        return wrapper_latest, version, hashes
+
+    details = "\n".join(f"  - {error}" for error in prefetch_errors)
+    msg = "Could not find a usable claude-code release"
+    if details:
+        msg = f"{msg}\n{details}"
+    raise ClaudeCodeConfigError(msg)
+
+
+def _hashes_match(
+    current_hashes: dict[str, str],
+    target_hashes: dict[str, str],
+) -> bool:
+    return all(
+        current_hashes.get(system) == target_hashes[system]
+        for system in PLATFORM_PACKAGES
+    )
+
+
+def _print_release_selection(
+    current_version: str,
+    wrapper_latest: str,
+    target_version: str,
+) -> None:
+    print(f"Current version: {current_version}")
+    print(f"Wrapper latest:  {wrapper_latest}")
+    print(f"Target version:  {target_version}")
+    if wrapper_latest != target_version:
+        print("Selected the newest version published for every supported platform.")
+
+
+def update_claude_code(*, verbose: bool = True) -> bool:
+    nix_path = _claude_code_nix_path()
+    content = common.read_text(nix_path)
+    current_version = _current_version_from_text(content)
+    current_hashes = _current_hashes_from_text(content)
+    wrapper_latest, target_version, hashes = _select_target_release(verbose=verbose)
+
+    if verbose:
+        _print_release_selection(current_version, wrapper_latest, target_version)
+
+    if current_version == target_version and _hashes_match(current_hashes, hashes):
+        print(f"✓ claude-code is up to date at version {current_version}")
+        return False
+
+    if verbose:
+        print("\nCalculated hashes:")
+        for system, hash_value in sorted(hashes.items()):
+            print(f"  {system}: {hash_value}")
+
+    updated_content = _update_nix_content(content, target_version, hashes)
+    common.write_text(nix_path, updated_content)
+
+    if current_version == target_version:
+        print(f"✓ Refreshed claude-code hashes for version {target_version}")
+        return True
+
+    print(f"✓ Updated claude-code from {current_version} to {target_version}")
+    return True
+
+
+def main() -> None:
+    try:
+        update_claude_code(verbose=False)
+        sys.exit(0)
+    except (
+        ClaudeCodeConfigError,
+        common.FetchError,
+        common.SubprocessError,
+        FileNotFoundError,
+    ) as exc:
+        print(f"\n❌ Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/scripts/update_lib.py
+++ b/scripts/update_lib.py
@@ -188,7 +188,7 @@ def calculate_hash(url: str, *, unpack: bool = True) -> Hash:
         cmd.append("--unpack")
     cmd.append(url)
 
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    result = common.run_command(cmd)
     hash_value = result.stdout.strip()
 
     return Hash(common.convert_nix_hash_to_sri(hash_value))

--- a/scripts/update_lib.py
+++ b/scripts/update_lib.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -20,6 +21,7 @@ import subprocess  # noqa: S404
 import sys
 import tarfile
 import tempfile
+import textwrap
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -247,6 +249,52 @@ def _extract_cargo_hash_from_output(output: str) -> Hash | None:
     return None
 
 
+def _build_flake_callpackage_expr(nix_file: Path) -> str | None:
+    """Build a flake-based Nix expression for package evaluation when available."""
+    repo_root = common.resolve_script_relative("..")
+    flake_file = repo_root / "flake.nix"
+    if not flake_file.exists():
+        return None
+
+    repo_root_json = json.dumps(str(repo_root))
+    nix_file_json = json.dumps(str(nix_file))
+
+    return textwrap.dedent(
+        f"""
+        let
+            flake = builtins.getFlake {repo_root_json};
+            system = builtins.currentSystem;
+            pkgs = import flake.inputs.nixpkgs {{
+                inherit system;
+                config.allowUnfree = true;
+                overlays = [
+                    (
+                        import
+                        "${{flake.outPath}}/config/home-manager/overlays/xmonad.nix"
+                    )
+                    (_final: _prev: {{
+                        unstable = import flake.inputs.nixpkgs-unstable {{
+                            inherit system;
+                            config.allowUnfree = true;
+                        }};
+                        claudius = flake.inputs.claudius.packages.${{system}}.default;
+                    }})
+                    (
+                        import
+                        "${{flake.outPath}}/config/home-manager/overlays/hm-compat.nix"
+                    )
+                    (
+                        import
+                        "${{flake.outPath}}/config/home-manager/overlays/darwin-workarounds.nix"
+                    )
+                ];
+            }};
+        in
+            pkgs.callPackage {nix_file_json} {{}}
+        """,
+    )
+
+
 def calculate_cargo_hash(nix_file: Path) -> Hash | None:  # noqa: C901, PLR0912, PLR0915
     """Calculate cargoHash by building with dummy hash and extract correct one."""
     # Create a temporary file with dummy cargoHash
@@ -272,10 +320,21 @@ def calculate_cargo_hash(nix_file: Path) -> Hash | None:  # noqa: C901, PLR0912,
     try:
         # Try to build and capture the error
         nixpkgs_url = "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz"
+        expr = _build_flake_callpackage_expr(Path(tmp_path))
+        if expr is None:
+            expr = (
+                'with import '
+                f'(fetchTarball "{nixpkgs_url}") {{}}; callPackage {tmp_path} '
+                f'{{ unstable = import (fetchTarball "{nixpkgs_url}") {{}}; }}'
+            )
+
         cmd = [
-            "nix-build", "-E",
-            f'with import (fetchTarball "{nixpkgs_url}") {{}}; callPackage {tmp_path} '
-            f'{{ unstable = import (fetchTarball "{nixpkgs_url}") {{}}; }}',
+            "nix-build",
+            "--option",
+            "experimental-features",
+            "nix-command flakes",
+            "-E",
+            expr,
         ]
 
         # Print debug info in CI environment


### PR DESCRIPTION
## Summary
- evaluate Codex cargo hashes through the repo flake so update automation sees the same overlays as normal builds
- switch Claude Code packaging to the published native platform tarballs instead of the deprecated npm wrapper layout
- harden the Claude Code updater to choose the newest version published for every supported platform and remain idempotent

## Root cause
- `scripts/update-codex-cli.py` delegated cargo hash calculation to `scripts/update_lib.py`, which evaluated a temporary `codex.nix` against plain `nixpkgs`; that dropped the repo overlays and failed on `pkgs.unstable`
- `config/home-manager/home/packages/claude-code.nix` still expected `@anthropic-ai/claude-code` to ship `cli.js`, but upstream now ships a thin wrapper package plus platform-specific native packages

## Verification
- `python3 -m py_compile scripts/update_lib.py scripts/update-codex-cli.py scripts/update-claude-code.py`
- `python3 scripts/update-claude-code.py && python3 scripts/update-claude-code.py`
- `./scripts/build-ai-tools.sh`
