### PR TITLE
fix(ci): migrate workflows off node20 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Check flake metadata
         run: nix flake metadata
@@ -48,17 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Run pre-commit hooks
         run: |
@@ -78,17 +72,14 @@ jobs:
             os: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Evaluate Home Manager configuration (no build)
         run: |
@@ -107,17 +98,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Build XMonad
         run: |

--- a/.github/workflows/update-ai-tools.yml
+++ b/.github/workflows/update-ai-tools.yml
@@ -17,18 +17,18 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore(ai-tools): update AI tools"
           title: "chore(ai-tools): update AI tools"
@@ -77,7 +77,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
@@ -90,13 +90,13 @@ jobs:
           fi
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore(ai-tools): update AI tools"
           title: "chore(ai-tools): update AI tools"

--- a/.github/workflows/update-cursor.yml
+++ b/.github/workflows/update-cursor.yml
@@ -15,22 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
             accept-flake-config = true
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
-
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -53,7 +50,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(cursor): update Cursor AppImage"

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -16,24 +16,40 @@ jobs:
     name: Update flake.lock
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
 
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v24
+        run: nix flake update
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v8
         with:
-          pr-title: "chore: update flake.lock"
-          pr-body: |
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update flake.lock"
+          title: "chore: update flake.lock"
+          body: |
             Automated update of `flake.lock` file.
 
             This PR updates the following inputs to their latest versions.
             Please review the changes and ensure all tests pass before merging.
-          pr-labels: |
+          labels: |
             dependencies
             automated
           branch: update-flake-lock
+          delete-branch: true

--- a/.github/workflows/update-vscode-extensions.yml
+++ b/.github/workflows/update-vscode-extensions.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -32,7 +32,7 @@ jobs:
         run: python3 scripts/update-vscode-extensions.py
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(vscode): update VSCode extensions"

--- a/.github/workflows/update-vscode-insiders.yml
+++ b/.github/workflows/update-vscode-insiders.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v14
+        uses: DeterminateSystems/nix-installer-action@v22
         with:
           extra-conf: |
             experimental-features = nix-command flakes
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -32,7 +32,7 @@ jobs:
         run: python3 scripts/update-vscode-insiders.py
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore(vscode): update VSCode Insiders"


### PR DESCRIPTION
## Summary
- upgrade GitHub-hosted actions to Node24-capable major versions
- drop `magic-nix-cache-action` from workflows because its latest release still runs on node20
- replace `DeterminateSystems/update-flake-lock` with explicit `nix flake update` + `create-pull-request` so the scheduled flake updater no longer inherits node20-only nested actions

## Details
- `actions/checkout`: `v4` -> `v6`
- `actions/setup-python`: `v5` -> `v6`
- `peter-evans/create-pull-request`: `v7` -> `v8`
- `DeterminateSystems/nix-installer-action`: `v14` -> `v22`
- remove `DeterminateSystems/magic-nix-cache-action`
- rewrite `update-flake.yml` to update `flake.lock` directly and open the PR with `create-pull-request@v8`

## Verification
- `nix develop --impure --command pre-commit run actionlint --files .github/workflows/ci.yml .github/workflows/update-ai-tools.yml .github/workflows/update-cursor.yml .github/workflows/update-flake.yml .github/workflows/update-vscode-extensions.yml .github/workflows/update-vscode-insiders.yml`
- `nix develop --impure --command pre-commit run yamllint --files .github/workflows/ci.yml .github/workflows/update-ai-tools.yml .github/workflows/update-cursor.yml .github/workflows/update-flake.yml .github/workflows/update-vscode-extensions.yml .github/workflows/update-vscode-insiders.yml`
- `nix develop --impure --command pre-commit run prettier --files .github/workflows/ci.yml .github/workflows/update-ai-tools.yml .github/workflows/update-cursor.yml .github/workflows/update-flake.yml .github/workflows/update-vscode-extensions.yml .github/workflows/update-vscode-insiders.yml`
