### PR TITLE
fix(codex): stabilize darwin codex-cli builds

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -114,7 +114,7 @@ let
     x86_64-linux = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
     aarch64-linux = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
     x86_64-darwin = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
-    aarch64-darwin = "sha256-ldBYkXlnC/h5HUhPC/CGwL6S0dxJzQsDEXA2DgJeDRE=";
+    aarch64-darwin = "sha256-V1Exqmqf7Viq6EeYAS05vURHEf/ElHpbBMqPUwuwyM0=";
   };
 
   rustyV8Version = "146.4.0";
@@ -139,17 +139,40 @@ let
     }.a.gz";
     hash = rustyV8ArchiveHashes.${pkgs.stdenv.system};
   };
+
+  livekitWebRtcTag = "webrtc-24f6822-2";
+
+  livekitWebRtcTriples = {
+    x86_64-linux = "linux-x64-release";
+    aarch64-linux = "linux-arm64-release";
+    x86_64-darwin = "mac-x64-release";
+    aarch64-darwin = "mac-arm64-release";
+  };
+
+  livekitWebRtcArchiveHashes = {
+    x86_64-linux = "sha256-aR76GGfK2UJheN5nI10e2f8CZPgxMxqlEPxyWc95AQ0=";
+    aarch64-linux = "sha256-evqmKOmnM+JuoWg+vJfvCppHWTnyeunKhWa3OTr8JE4=";
+    x86_64-darwin = "sha256-XapngujlXtcDEGd2hacmP3nHFycEVZRybO/ORHPc6Og=";
+    aarch64-darwin = "sha256-4IwJM6EzTFgQd2AdX+Hj9NWzmyqXrSioRax2L6GKL1U=";
+  };
+
+  livekitWebRtcArchive = pkgs.fetchzip {
+    url = "https://github.com/livekit/rust-sdks/releases/download/${livekitWebRtcTag}/webrtc-${
+      livekitWebRtcTriples.${pkgs.stdenv.system}
+    }.zip";
+    hash = livekitWebRtcArchiveHashes.${pkgs.stdenv.system};
+  };
 in
 rustPlatform.buildRustPackage (
   rec {
     pname = "codex-cli";
-    version = "rust-v0.118.0";
+    version = "rust-v0.130.0";
 
     src = pkgs.fetchFromGitHub {
       owner = "openai";
       repo = "codex";
       rev = "${version}";
-      hash = "sha256-FdtV+CIqTInnegcXrXBxw4aE0JnNDh4GdYKwUDjSk9Y=";
+      hash = "sha256-YeUeYbzUMUx0lhIKdtPa8vUYK2Cj1hmbLb68Y80r71o=";
     };
 
     sourceRoot = "source/codex-rs";
@@ -179,6 +202,18 @@ rustPlatform.buildRustPackage (
       # Match upstream Codex's rusty_v8 prebuilt archive handling.
       patch -d "''${vendored_v8_dirs[0]}" -p1 < ${./rusty-v8-prebuilt-out-dir.patch}
     ''
+    + pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+            # Apple's newer linker can overflow ARM64 branch ranges when linking the
+            # WebRTC-heavy Codex binary. Force the classic linker on Darwin targets.
+            cat >> .cargo/config.toml <<'EOF'
+
+      [target.x86_64-apple-darwin]
+      rustflags = ["-C", "link-arg=-ld_classic"]
+
+      [target.aarch64-apple-darwin]
+      rustflags = ["-C", "link-arg=-ld_classic"]
+      EOF
+    ''
     + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
       # LLVM 21 / rustc 1.91.1 currently crashes in release optimization passes
       # for this workspace. Lower Linux release optimization until nixpkgs updates.
@@ -195,16 +230,20 @@ rustPlatform.buildRustPackage (
     # To test: remove this line and run `nix build .#codex-cli`
     CARGO_PROFILE_RELEASE_LTO = "off";
 
-    # Upstream pins codegen-units=1 for smaller binaries, but that currently
-    # triggers an LLVM 21 / rustc 1.91.1 SIGSEGV while compiling `image` on Linux.
-    # Use multiple codegen units until nixpkgs moves past the buggy toolchain.
-    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16";
+    # Upstream pins codegen-units=1 for smaller binaries. Keep that on Darwin,
+    # where we need to minimize link distance for the large WebRTC static
+    # archive. Linux still needs multiple codegen units to avoid an LLVM 21 /
+    # rustc 1.91.1 SIGSEGV while compiling `image`.
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = if pkgs.stdenv.isLinux then "16" else "1";
 
     # Show backtrace for build failures
     RUST_BACKTRACE = "1";
 
     # Keep rusty_v8 fully offline inside the Nix sandbox.
     RUSTY_V8_ARCHIVE = "${rustyV8Archive}";
+
+    # Keep LiveKit WebRTC fully offline inside the Nix sandbox.
+    LK_CUSTOM_WEBRTC = "${livekitWebRtcArchive}";
 
     # Point rama-boring-sys to our pre-built patched BoringSSL
     BORING_BSSL_PATH = "${ramaBoringssl}";
@@ -234,7 +273,8 @@ rustPlatform.buildRustPackage (
         stdenv.cc.cc.lib # for libgcc_s.so.1
       ];
 
-    # Ensure C++ standard library is linked for BoringSSL
+    # Ensure libc++ is linked on Darwin. The classic linker is selected via the
+    # target-specific rustflags injected into `.cargo/config.toml` above.
     NIX_LDFLAGS = pkgs.lib.optionalString pkgs.stdenv.isDarwin "-lc++";
 
     doCheck = false;
@@ -249,6 +289,11 @@ rustPlatform.buildRustPackage (
       license = licenses.asl20;
       mainProgram = "codex";
     };
+  }
+  // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+    # Favor smaller release binaries on Darwin so the final WebRTC-heavy link
+    # stays within ARM64 branch range limits.
+    CARGO_PROFILE_RELEASE_OPT_LEVEL = "s";
   }
   // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
     # Point openssl-sys to system OpenSSL on Linux (avoid BoringSSL detection)

--- a/config/home-manager/home/packages/stub-runfiles.patch
+++ b/config/home-manager/home/packages/stub-runfiles.patch
@@ -1,7 +1,7 @@
 diff -urN orig/Cargo.lock mod/Cargo.lock
 --- orig/Cargo.lock
 +++ mod/Cargo.lock
-@@ -8213,7 +8213,6 @@
+@@ -10910,7 +10910,6 @@
  [[package]]
  name = "runfiles"
  version = "0.1.0"
@@ -12,15 +12,15 @@ diff -urN orig/Cargo.lock mod/Cargo.lock
 diff -urN orig/Cargo.toml mod/Cargo.toml
 --- orig/Cargo.toml
 +++ mod/Cargo.toml
-@@ -263,7 +263,7 @@
+@@ -333,7 +333,7 @@
  regex-lite = "0.1.8"
- reqwest = "0.12"
+ reqwest = { version = "0.12", features = ["cookies"] }
  rmcp = { version = "0.15.0", default-features = false }
 -runfiles = { git = "https://github.com/dzbarsky/rules_rust", rev = "b56cbaa8465e74127f1ea216f813cd377295ad81" }
 +runfiles = { path = "utils/runfiles-stub" }
- v8 = "=146.4.0"
  rustls = { version = "0.23", default-features = false, features = [
      "ring",
+     "std",
 diff -urN orig/utils/runfiles-stub/Cargo.toml mod/utils/runfiles-stub/Cargo.toml
 --- orig/utils/runfiles-stub/Cargo.toml
 +++ mod/utils/runfiles-stub/Cargo.toml

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -258,12 +258,18 @@ def run_command(
         raise SubprocessError(" ".join(cmd), exc) from exc
 
 
-def run_nix_prefetch(url: str, *, timeout: int = SUBPROCESS_TIMEOUT) -> str:
+def run_nix_prefetch(
+    url: str,
+    *,
+    timeout: int = SUBPROCESS_TIMEOUT,
+    unpack: bool = False,
+) -> str:
     """Run nix-prefetch-url and return sha256 hash.
 
     Args:
         url: URL to prefetch
         timeout: Command timeout in seconds
+        unpack: Whether to hash the unpacked archive contents
 
     Returns:
         SHA256 hash string
@@ -272,19 +278,30 @@ def run_nix_prefetch(url: str, *, timeout: int = SUBPROCESS_TIMEOUT) -> str:
         SubprocessError: On command failure
         subprocess.TimeoutExpired: On timeout
     """
-    result = run_command(["nix-prefetch-url", url], timeout=timeout)
+    cmd = ["nix-prefetch-url"]
+    if unpack:
+        cmd.append("--unpack")
+    cmd.append(url)
+    result = run_command(cmd, timeout=timeout)
     return result.stdout.strip()
 
 
-def run_nix_prefetch_sri(url: str, *, timeout: int = SUBPROCESS_TIMEOUT) -> str:
+def run_nix_prefetch_sri(
+    url: str,
+    *,
+    timeout: int = SUBPROCESS_TIMEOUT,
+    unpack: bool = False,
+) -> str:
     """Prefetch URL and return an SRI sha256 hash.
 
-    Prefer `nix store prefetch-file --json` because it returns the SRI hash directly.
-    Fall back to `nix-prefetch-url` plus hash conversion for older Nix versions.
+    Prefer `nix store prefetch-file --json` when the current Nix supports the
+    requested mode. Fall back to `nix-prefetch-url` plus hash conversion for
+    older Nix versions or when unpacked archive hashing is requested.
 
     Args:
         url: URL to prefetch
         timeout: Command timeout in seconds
+        unpack: Whether to hash the unpacked archive contents
 
     Returns:
         SHA256 hash in SRI format
@@ -294,8 +311,12 @@ def run_nix_prefetch_sri(url: str, *, timeout: int = SUBPROCESS_TIMEOUT) -> str:
         SubprocessError: If all supported prefetch commands fail
     """
     try:
+        cmd = ["nix", "store", "prefetch-file", "--json", "--hash-type", "sha256"]
+        if unpack:
+            cmd.append("--unpack")
+        cmd.append(url)
         result = run_command(
-            ["nix", "store", "prefetch-file", "--json", "--hash-type", "sha256", url],
+            cmd,
             timeout=timeout,
         )
         data = json.loads(result.stdout)
@@ -304,7 +325,18 @@ def run_nix_prefetch_sri(url: str, *, timeout: int = SUBPROCESS_TIMEOUT) -> str:
             raise PrefetchError(url, "missing hash field in nix prefetch output")
     except SubprocessError:
         # Fall back to nix-prefetch-url for environments without prefetch-file.
-        nix32_hash = run_nix_prefetch(url, timeout=timeout)
+        nix32_hash = run_nix_prefetch(url, timeout=timeout, unpack=unpack)
+        if unpack:
+            first_line = next(
+                (line.strip() for line in nix32_hash.splitlines() if line.strip()),
+                "",
+            )
+            if not first_line:
+                raise PrefetchError(
+                    url,
+                    "missing unpack hash in nix-prefetch-url output",
+                ) from None
+            nix32_hash = first_line
         return convert_nix_hash_to_sri(nix32_hash, timeout=timeout)
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         raise PrefetchError(url, exc) from exc

--- a/scripts/update-codex-cli.py
+++ b/scripts/update-codex-cli.py
@@ -2,8 +2,9 @@
 """Update codex-cli tool using functional programming style.
 
 This script updates codex-cli metadata in Nix and maintains per-platform
-cargoHashes and rusty_v8 archive hashes. It fetches the latest version from
-GitHub releases and generates the appropriate hashes.
+cargoHashes, rusty_v8 archive hashes, and LiveKit WebRTC archive hashes. It
+fetches the latest version from GitHub releases and generates the appropriate
+hashes.
 
 Usage:
     ./update-codex-cli.py
@@ -82,6 +83,25 @@ _RUSTY_V8_VERSION_PATTERN = re.compile(
     r'(^\s*rustyV8Version\s*=\s*")([^"]+)(";\s*$)',
     re.MULTILINE,
 )
+_LIVEKIT_WEBRTC_TAG_PATTERN = re.compile(
+    r'(^\s*livekitWebRtcTag\s*=\s*")([^"]+)(";\s*$)',
+    re.MULTILINE,
+)
+_LIVEKIT_WEBRTC_SOURCE_PATTERN = re.compile(
+    r'git\+https://github\.com/(?P<repo>[^?\n"]*?/rust-sdks)\.git\?rev='
+    r'(?P<rev>[0-9a-f]{40})#',
+)
+_LIVEKIT_WEBRTC_TAG_SOURCE_PATTERN = re.compile(
+    r'^\s*pub const WEBRTC_TAG: &str = "([^"]+)";\s*$',
+    re.MULTILINE,
+)
+
+_LIVEKIT_WEBRTC_TRIPLES = {
+    "x86_64-linux": "linux-x64-release",
+    "aarch64-linux": "linux-arm64-release",
+    "x86_64-darwin": "mac-x64-release",
+    "aarch64-darwin": "mac-arm64-release",
+}
 
 _RUNFILES_DEP_PATTERN = re.compile(
     r'^(?P<indent>\s*)runfiles\s*=\s*\{[^}]*github\.com/dzbarsky/rules_rust[^}]*\}\s*$',
@@ -301,6 +321,11 @@ def _extract_rusty_v8_version(content: str) -> str | None:
     return match.group(2) if match else None
 
 
+def _extract_livekit_webrtc_tag(content: str) -> str | None:
+    match = _LIVEKIT_WEBRTC_TAG_PATTERN.search(content)
+    return match.group(2) if match else None
+
+
 def _update_rusty_v8_version(content: str, version: str) -> str:
     updated, replacements = _RUSTY_V8_VERSION_PATTERN.subn(
         rf'\1{version}\3',
@@ -309,6 +334,18 @@ def _update_rusty_v8_version(content: str, version: str) -> str:
     )
     if replacements != 1:
         msg = "Could not find rustyV8Version assignment in codex.nix"
+        raise ValueError(msg)
+    return updated
+
+
+def _update_livekit_webrtc_tag(content: str, tag: str) -> str:
+    updated, replacements = _LIVEKIT_WEBRTC_TAG_PATTERN.subn(
+        rf'\1{tag}\3',
+        content,
+        count=1,
+    )
+    if replacements != 1:
+        msg = "Could not find livekitWebRtcTag assignment in codex.nix"
         raise ValueError(msg)
     return updated
 
@@ -359,6 +396,52 @@ def _update_rusty_v8_archive_hashes(
     return content[:match.start("body")] + updated_body + content[match.end("body"):]
 
 
+def _extract_livekit_webrtc_archive_hashes(content: str) -> dict[str, str]:
+    match = re.search(
+        r'livekitWebRtcArchiveHashes\s*=\s*{\n(?P<body>.*?)};',
+        content,
+        re.DOTALL,
+    )
+    if not match:
+        return {}
+
+    body = match.group("body")
+    return {
+        entry.group(1): entry.group(2)
+        for entry in re.finditer(
+            r'^\s*([A-Za-z0-9_-]+)\s*=\s*"([^"]+)";',
+            body,
+            re.MULTILINE,
+        )
+    }
+
+
+def _update_livekit_webrtc_archive_hashes(
+    content: str, hashes: dict[str, str],
+) -> str:
+    match = re.search(
+        r'livekitWebRtcArchiveHashes\s*=\s*{\n(?P<body>.*?)};',
+        content,
+        re.DOTALL,
+    )
+    if not match:
+        msg = "Could not find livekitWebRtcArchiveHashes block in codex.nix"
+        raise ValueError(msg)
+
+    body = match.group("body")
+    indent_match = re.search(
+        r'^(\s*)[A-Za-z0-9_-]+\s*=\s*"[^"]+";',
+        body,
+        re.MULTILINE,
+    )
+    entry_indent = indent_match.group(1) if indent_match else "    "
+    updated_body = "\n".join(
+        f'{entry_indent}{system} = "{hashes[system]}";'
+        for system in _LIVEKIT_WEBRTC_TRIPLES
+    )
+    return content[:match.start("body")] + updated_body + content[match.end("body"):]
+
+
 def _rusty_v8_archive_url(version: str, system: str) -> str:
     target = _RUSTY_V8_TARGETS[system]
     return (
@@ -386,11 +469,61 @@ def _calculate_rusty_v8_archive_hashes(version: str) -> dict[str, str]:
     }
 
 
+def _extract_rust_sdks_source(source_dir: Path) -> tuple[str, str]:
+    cargo_lock = source_dir / "Cargo.lock"
+    match = _LIVEKIT_WEBRTC_SOURCE_PATTERN.search(
+        cargo_lock.read_text(encoding="utf-8"),
+    )
+    if not match:
+        msg = f"Could not find rust-sdks source in {cargo_lock}"
+        raise RuntimeError(msg)
+    return match.group("repo"), match.group("rev")
+
+
+def _extract_upstream_livekit_webrtc_tag(repo: str, rev: str) -> str:
+    source = _download_text(
+        f"https://raw.githubusercontent.com/{repo}/{rev}/webrtc-sys/build/src/lib.rs",
+    )
+    match = _LIVEKIT_WEBRTC_TAG_SOURCE_PATTERN.search(source)
+    if not match:
+        msg = f"Could not find WEBRTC_TAG in rust-sdks {repo}@{rev}"
+        raise RuntimeError(msg)
+    return match.group(1)
+
+
+def _livekit_webrtc_archive_url(tag: str, system: str) -> str:
+    triple = _LIVEKIT_WEBRTC_TRIPLES[system]
+    return (
+        "https://github.com/livekit/rust-sdks/releases/download/"
+        f"{tag}/webrtc-{triple}.zip"
+    )
+
+
+def _prefetch_unpacked_file_hash(url: str) -> str:
+    return common.run_nix_prefetch_sri(url, timeout=1800, unpack=True)
+
+
+def _calculate_livekit_webrtc_archive_hashes(tag: str) -> dict[str, str]:
+    return {
+        system: _prefetch_unpacked_file_hash(
+            _livekit_webrtc_archive_url(tag, system),
+        )
+        for system in _LIVEKIT_WEBRTC_TRIPLES
+    }
+
+
 def _needs_rusty_v8_update(content: str, version: str) -> bool:
     if _extract_rusty_v8_version(content) != version:
         return True
     hashes = _extract_rusty_v8_archive_hashes(content)
     return any(system not in hashes for system in _RUSTY_V8_TARGETS)
+
+
+def _needs_livekit_webrtc_update(content: str, tag: str) -> bool:
+    if _extract_livekit_webrtc_tag(content) != tag:
+        return True
+    hashes = _extract_livekit_webrtc_archive_hashes(content)
+    return any(system not in hashes for system in _LIVEKIT_WEBRTC_TRIPLES)
 
 
 def _detect_system() -> str:
@@ -532,10 +665,11 @@ def _refresh_release_metadata(
     latest_version: lib.Version,
     *,
     version_updated: bool,
-) -> tuple[str, lib.Hash, str]:
+) -> tuple[str, lib.Hash, str, str]:
     updated_content = content
     latest_hash = current_hash
     rusty_v8_version = _extract_rusty_v8_version(updated_content)
+    livekit_webrtc_tag = _extract_livekit_webrtc_tag(updated_content)
 
     if version_updated:
         latest_hash = lib.calculate_hash(
@@ -557,14 +691,36 @@ def _refresh_release_metadata(
             tarball_path = _download_release_tarball(latest_version, temp_root)
             source_dir = _extract_codex_source_tree(tarball_path, temp_root)
             rusty_v8_version = _extract_upstream_rusty_v8_version(source_dir)
+            rust_sdks_repo, rust_sdks_rev = _extract_rust_sdks_source(source_dir)
+            livekit_webrtc_tag = _extract_upstream_livekit_webrtc_tag(
+                rust_sdks_repo,
+                rust_sdks_rev,
+            )
     elif not RUSTY_V8_PATCH_FILE.exists():
         _regenerate_rusty_v8_patch(latest_version)
 
-    if rusty_v8_version is None:
-        msg = "Could not determine rusty_v8 version"
+    if rusty_v8_version is None or livekit_webrtc_tag is None:
+        with tempfile.TemporaryDirectory(prefix="codex-upstream-metadata-") as temp_dir:
+            temp_root = Path(temp_dir)
+            tarball_path = _download_release_tarball(latest_version, temp_root)
+            source_dir = _extract_codex_source_tree(tarball_path, temp_root)
+            rusty_v8_version = rusty_v8_version or _extract_upstream_rusty_v8_version(
+                source_dir,
+            )
+            rust_sdks_repo, rust_sdks_rev = _extract_rust_sdks_source(source_dir)
+            livekit_webrtc_tag = (
+                livekit_webrtc_tag
+                or _extract_upstream_livekit_webrtc_tag(
+                    rust_sdks_repo,
+                    rust_sdks_rev,
+                )
+            )
+
+    if rusty_v8_version is None or livekit_webrtc_tag is None:
+        msg = "Could not determine upstream Codex archive metadata"
         raise RuntimeError(msg)
 
-    return updated_content, latest_hash, rusty_v8_version
+    return updated_content, latest_hash, rusty_v8_version, livekit_webrtc_tag
 
 
 def _refresh_rusty_v8_metadata(content: str, rusty_v8_version: str) -> str:
@@ -575,6 +731,17 @@ def _refresh_rusty_v8_metadata(content: str, rusty_v8_version: str) -> str:
     return _update_rusty_v8_archive_hashes(
         updated_content,
         _calculate_rusty_v8_archive_hashes(rusty_v8_version),
+    )
+
+
+def _refresh_livekit_webrtc_metadata(content: str, tag: str) -> str:
+    if not _needs_livekit_webrtc_update(content, tag):
+        return content
+
+    updated_content = _update_livekit_webrtc_tag(content, tag)
+    return _update_livekit_webrtc_archive_hashes(
+        updated_content,
+        _calculate_livekit_webrtc_archive_hashes(tag),
     )
 
 
@@ -591,15 +758,21 @@ def main() -> int:
     latest_version = lib.fetch_github_release(GITHUB_REPO, VERSION_PREFIX)
 
     version_updated = current.version != latest_version
-    updated_content, latest_hash, rusty_v8_version = _refresh_release_metadata(
-        content,
-        current.hash,
-        latest_version,
-        version_updated=version_updated,
+    updated_content, latest_hash, rusty_v8_version, livekit_webrtc_tag = (
+        _refresh_release_metadata(
+            content,
+            current.hash,
+            latest_version,
+            version_updated=version_updated,
+        )
     )
     updated_content = _refresh_rusty_v8_metadata(
         updated_content,
         rusty_v8_version,
+    )
+    updated_content = _refresh_livekit_webrtc_metadata(
+        updated_content,
+        livekit_webrtc_tag,
     )
 
     if _needs_cargo_update(


### PR DESCRIPTION
## Summary
- vendor LiveKit WebRTC archives in the Nix package and pass them through `LK_CUSTOM_WEBRTC` so `webrtc-sys` stays offline inside the sandbox
- force the Darwin build to use the classic linker and smaller release settings so arm64 links stop failing with branch range overflows
- teach `scripts/update-codex-cli.py` to refresh LiveKit WebRTC tags and unpacked archive hashes during future updates

## Testing
- `nix build --impure --no-link .#homeConfigurations.aarch64-darwin.activationPackage`
- `python3 -m py_compile scripts/common.py scripts/update-codex-cli.py`
- `python3 scripts/update-codex-cli.py`