### PR TITLE
feat(claudius): improve setup skills

### DIFF
--- a/config/claudius/docs/skills/catalog.yaml
+++ b/config/claudius/docs/skills/catalog.yaml
@@ -74,6 +74,9 @@ skills:
   setup-biome:
     category: frontend-typescript
     kind: building-block
+  setup-pandacss:
+    category: frontend-typescript
+    kind: building-block
   setup-ts-typecheck:
     category: frontend-typescript
     kind: building-block

--- a/config/claudius/docs/skills/inventory.yaml
+++ b/config/claudius/docs/skills/inventory.yaml
@@ -235,6 +235,17 @@ skills:
       Strong standalone value for JS/TS projects. Still best treated as one building
       block inside a broader project baseline.
 
+  setup-pandacss:
+    topic: frontend-typescript
+    role: building-block
+    exposure: primary
+    future_action: keep-standalone-and-compose-into-future-js-baseline
+    successor: []
+    rationale: >-
+      PandaCSS adoption is a meaningful frontend architecture decision. It should
+      be directly available for React/React Router apps while still composing with
+      Biome, TypeScript type checks, Storybook, and local quality-loop skills.
+
   setup-ts-typecheck:
     topic: frontend-typescript
     role: building-block

--- a/config/claudius/skills/setup-github-guardrails/instructions.md
+++ b/config/claudius/skills/setup-github-guardrails/instructions.md
@@ -75,7 +75,22 @@ permissions:
 Add broader permissions only when a workflow actually needs them, for example `id-token: write` for
 OIDC-based cloud access.
 
-### 5. Preserve the lint policy surface
+### 5. Pin reusable Actions for reproducibility
+
+For mature infrastructure repositories, prefer full commit SHA pins for every `uses:` reference.
+Keep the intended semantic version in a nearby comment and re-resolve it explicitly on upgrades:
+
+```shell
+git ls-remote https://github.com/<owner>/<repo>.git 'refs/tags/<tag>^{}'
+```
+
+Use the peeled `^{}` ref for annotated tags so the result is the target commit, not the tag object.
+If the peeled ref is absent because the tag is lightweight, use the direct `refs/tags/<tag>` value.
+
+Tag pins are acceptable only as a temporary bootstrap state or when the repository explicitly trades
+strict reproducibility for automated Action updates.
+
+### 6. Preserve the lint policy surface
 
 Ensure the repo-wide lint workflow keeps:
 
@@ -84,14 +99,14 @@ Ensure the repo-wide lint workflow keeps:
 - PR-title lint when commitlint is present
 - stable job names that can be required in branch protection
 
-### 6. Recommend or apply branch protection carefully
+### 7. Recommend or apply branch protection carefully
 
 If the user explicitly asks for hosted enforcement and `gh` is available and authenticated,
 configure branch protection only after listing the exact checks that will be required.
 
 Otherwise, summarize the recommended required checks and leave the hosted settings unchanged.
 
-### 7. Finish cleanly
+### 8. Finish cleanly
 
 Summarize:
 

--- a/config/claudius/skills/setup-local-quality-loop/instructions.md
+++ b/config/claudius/skills/setup-local-quality-loop/instructions.md
@@ -25,7 +25,7 @@ Extract:
 - the allowed commitlint scopes
 - the expected `CI - Lint` naming surface
 - the preferred hook names
-- any profile-specific CI initialization or skip rules
+- any profile-specific CI initialization rules and local/CI parity requirements
 
 ## Steps
 
@@ -104,7 +104,7 @@ After generation, ensure the local and CI surface matches the profile:
 - commitlint and PR-title lint run after `pre-commit`
 - dependency installation happens before `pre-commit`
 - `fetch-depth: 0` is preserved
-- `SKIP` is used only for profile-approved hooks and documented inline
+- CI does not skip local hooks by default; any `SKIP` entry is a last resort with an inline reason
 
 ### 6. Finish cleanly
 

--- a/config/claudius/skills/setup-nix-ci-lint/assets/lint.yml.template
+++ b/config/claudius/skills/setup-nix-ci-lint/assets/lint.yml.template
@@ -12,24 +12,26 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # v4 resolved on 2026-05-20. Re-resolve before intentionally upgrading.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: DeterminateSystems/determinate-nix-action@v3
+        # v3 resolved on 2026-05-20. Re-resolve before intentionally upgrading.
+        uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f
 
       - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        # v13 resolved on 2026-05-20. Re-resolve before intentionally upgrading.
+        uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39
 
       # Hook-specific initialization steps go here (see step 3)
 
       # Project-specific dependency installation steps go here (see step 5)
 
       - name: Run pre-commit hooks
-        run: nix develop -c pre-commit run --all-files
+        run: nix develop -c pre-commit run --all-files --show-diff-on-failure
 
       # Commitlint CI steps go here if applicable (see step 6)

--- a/config/claudius/skills/setup-nix-ci-lint/instructions.md
+++ b/config/claudius/skills/setup-nix-ci-lint/instructions.md
@@ -16,9 +16,15 @@ Read `flake.nix` in the project root and extract:
 Create the workflow using [lint.yml.template](assets/lint.yml.template) as the base structure. The base provides:
 - Trigger on `pull_request` and `push` to all branches
 - Checkout with `fetch-depth: 0` (needed for commitlint range checks)
-- `DeterminateSystems/determinate-nix-action@v3` for Nix installation
-- `DeterminateSystems/magic-nix-cache-action@v13` for build caching
-- `nix develop -c pre-commit run --all-files` to run all hooks
+- minimal `contents: read` permissions by default
+- SHA-pinned GitHub Actions for Nix installation and build caching
+- `nix develop -c pre-commit run --all-files --show-diff-on-failure` to run all hooks
+
+For mature infrastructure repositories, do not leave tag-based `uses:` references in the final
+workflow. If an Action version needs to change, resolve the intended tag to a full commit SHA with
+`git ls-remote https://github.com/<owner>/<repo>.git 'refs/tags/<tag>^{}'` and keep the
+human-readable tag in the step name or an adjacent comment. Use the peeled `^{}` ref for annotated
+tags; if it is absent because the tag is lightweight, use the direct `refs/tags/<tag>` value.
 
 ### 3. Add hook-specific initialization steps
 
@@ -26,19 +32,25 @@ Inspect the hooks from step 1. If any of the following hooks are enabled, insert
 
 | Hook | Initialization step |
 |---|---|
-| `tflint` | `nix run nixpkgs#tflint -- --init` |
+| `tflint` | `nix develop -c tflint --init` |
 
 If no hooks need initialization, skip this step.
 
-### 4. Determine hooks to skip in CI
+When using `git-hooks.nix`, the enabled hook package for `tflint` may be a per-file wrapper rather
+than the real CLI. Verify `nix develop -c bash -lc 'head -n 2 "$(command -v tflint)"'` before relying
+on it. If it is a wrapper, add the real `pkgs.tflint` to `devShells.default.packages` before
+`pre-commit-check.enabledPackages` so `nix develop -c tflint --init` resolves to the real binary
+while the pre-commit hook still uses its generated wrapper entry.
 
-Some hooks require resources not available in CI (e.g. cloud credentials, running backends). If any of the following hooks are enabled, add them to the `SKIP` environment variable on the "Run pre-commit hooks" step:
+### 4. Preserve local/CI parity
 
-| Hook | Reason to skip |
-|---|---|
-| `tofu-validate-no-backend` | Requires `tofu init` which may need provider credentials |
+Do not skip hooks in CI by default. The repo-wide lint workflow should exercise the same checks as
+`pre-commit run --all-files` in the project dev shell.
 
-Format: `SKIP: hook1,hook2` as an `env` entry. If nothing needs to be skipped, do not add the `env` block.
+If a hook cannot run in CI, first try to make it deterministic and backend-free. For OpenTofu
+validation, prefer `tofu init -backend=false` with locked providers, metadata lookup disabled, and
+no cloud credentials. Add `SKIP` only when the hook still requires an unavailable external resource,
+and document the concrete reason inline next to the `SKIP` entry.
 
 ### 5. Add project-specific dependency installation steps
 
@@ -58,3 +70,6 @@ If commitlint hooks are not present, skip this step.
 - Do NOT hardcode project-specific details. Derive everything from the flake.nix configuration.
 - The `fetch-depth: 0` on checkout is required for commitlint `--from`/`--to` range checks to work. Always include it even if commitlint is not yet configured, to avoid needing to change it later.
 - The Determinate Systems actions handle Nix installation and caching. Do NOT use `cachix/install-nix-action` or other alternatives.
+- Keep lint workflow permissions at `contents: read` unless a step demonstrably needs broader access.
+- Run hook initialization inside the project flake/dev shell so CI cannot silently drift from the pinned local toolchain.
+- Confirm hook initialization commands resolve to real tool CLIs, not git-hooks wrapper scripts.

--- a/config/claudius/skills/setup-nix-ci-lint/skill.yaml
+++ b/config/claudius/skills/setup-nix-ci-lint/skill.yaml
@@ -1,8 +1,9 @@
 version: 1
 name: setup-nix-ci-lint
 description: Generate a GitHub Actions lint CI workflow from the project's flake.nix
-  hook configuration, using Determinate Systems Nix actions. Use when setting up lint
-  CI for a Nix project with pre-commit hooks.
+  hook configuration, using Determinate Systems Nix actions. Use when setting up a
+  reproducible lint CI for a Nix project with pre-commit hooks, minimal permissions,
+  project-flake-managed tools, and local/CI hook parity.
 targets:
   claude-code:
     invocation: manual

--- a/config/claudius/skills/setup-nix-lint/assets/formatter.nix.template
+++ b/config/claudius/skills/setup-nix-lint/assets/formatter.nix.template
@@ -1,9 +1,14 @@
 formatter = pkgs.writeShellScriptBin "nixfmt-wrapper" ''
   set -euo pipefail
   if [ "$#" -gt 0 ]; then
-    exec ${pkgs.nixfmt}/bin/nixfmt "$@"
+    mapfile -t files < <(
+      ${pkgs.git}/bin/git ls-files -- "$@" \
+        | ${pkgs.gnugrep}/bin/grep -E '\.nix$' \
+        || true
+    )
+  else
+    mapfile -t files < <(${pkgs.git}/bin/git ls-files '*.nix')
   fi
-  mapfile -t files < <(${pkgs.git}/bin/git ls-files '*.nix')
   if [ "''${#files[@]}" -eq 0 ]; then
     exit 0
   fi

--- a/config/claudius/skills/setup-nix-lint/instructions.md
+++ b/config/claudius/skills/setup-nix-lint/instructions.md
@@ -23,8 +23,9 @@ Hooks added:
 Add the formatter output from [formatter.nix.template](assets/formatter.nix.template) to the flake outputs (sibling of `checks` and `devShells`). Skip if a `formatter` output already exists.
 
 This provides `nix fmt` support via a wrapper that:
-- Formats specific files when arguments are given
+- Formats only git-tracked `.nix` files under the given path arguments
 - Formats all git-tracked `.nix` files when no arguments are given
+- Avoids passing directories such as `.` or `.direnv` directly to `nixfmt`
 
 ## Important Notes
 

--- a/config/claudius/skills/setup-pandacss/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-pandacss/assets/hooks.nix.template
@@ -1,0 +1,1 @@
+pandacss-practices = mkHook "pandacss-practices" "node scripts/check-pandacss-practices.mjs";

--- a/config/claudius/skills/setup-pandacss/assets/panda-practices-check.mjs.template
+++ b/config/claudius/skills/setup-pandacss/assets/panda-practices-check.mjs.template
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const sourceRoots = splitEnv('PANDACSS_CHECK_ROOTS', ['src', '.storybook', 'app', 'routes', 'components']);
+const tokenPathFragments = splitEnv('PANDACSS_CHECK_TOKEN_PATHS', [
+  'panda.config.',
+  'tokens.',
+  'semantic-tokens',
+  `${path.sep}theme${path.sep}`,
+  `${path.sep}tokens${path.sep}`,
+  `${path.sep}global.css`,
+  `${path.sep}globals.css`,
+  `${path.sep}global-styles`,
+  `${path.sep}globalStyles`,
+  `${path.sep}style-layers.css`,
+  `${path.sep}storybook-overrides.css`,
+]);
+const runtimeVariablePathFragments = splitEnv('PANDACSS_CHECK_RUNTIME_VAR_PATHS', []);
+const ignoredPathFragments = splitEnv('PANDACSS_CHECK_IGNORE_PATHS', [
+  `${path.sep}node_modules${path.sep}`,
+  `${path.sep}dist${path.sep}`,
+  `${path.sep}build${path.sep}`,
+  `${path.sep}storybook-static${path.sep}`,
+  `${path.sep}styled-system${path.sep}`,
+]);
+const sourceExtensions = new Set(['.js', '.jsx', '.ts', '.tsx', '.css', '.mdx']);
+const rawColorPattern = /#[0-9a-fA-F]{3,8}\b|rgba?\(|hsla?\(/;
+const cssVariablePattern = /var\(--/;
+const inlineStylePattern = /\bstyle\s*=/;
+
+const errors = [];
+
+checkPandaConfig();
+checkPackageScripts();
+checkSources();
+
+if (errors.length > 0) {
+  console.error('PandaCSS practice check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log('PandaCSS practice check passed.');
+
+function splitEnv(name, fallback) {
+  const value = process.env[name];
+  if (!value) return fallback;
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function read(relativePath) {
+  return readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function checkPandaConfig() {
+  const configPath = ['panda.config.ts', 'panda.config.mts', 'panda.config.js', 'panda.config.mjs'].find((file) =>
+    existsSync(path.join(root, file)),
+  );
+
+  if (!configPath) {
+    errors.push('missing panda.config.ts/js');
+    return;
+  }
+
+  const config = read(configPath);
+  if (!/strictTokens\s*:\s*true/.test(config)) {
+    errors.push(`${configPath}: expected strictTokens: true`);
+  }
+  if (!/jsxFramework\s*:\s*['"]react['"]/.test(config)) {
+    errors.push(`${configPath}: expected jsxFramework: 'react'`);
+  }
+  if (!/include\s*:/.test(config)) {
+    errors.push(`${configPath}: expected explicit include globs`);
+  }
+}
+
+function checkPackageScripts() {
+  const packagePath = path.join(root, 'package.json');
+  if (!existsSync(packagePath)) {
+    errors.push('missing package.json');
+    return;
+  }
+
+  const pkg = JSON.parse(readFileSync(packagePath, 'utf8'));
+  if (!pkg.scripts?.['panda:codegen']) {
+    errors.push('package.json: missing scripts.panda:codegen');
+  }
+  if (!pkg.devDependencies?.['@pandacss/dev'] && !pkg.dependencies?.['@pandacss/dev']) {
+    errors.push('package.json: missing @pandacss/dev dependency');
+  }
+}
+
+function checkSources() {
+  for (const sourceRoot of sourceRoots) {
+    const absoluteRoot = path.join(root, sourceRoot);
+    if (!existsSync(absoluteRoot)) continue;
+    if (hasPathFragment(absoluteRoot, ignoredPathFragments)) continue;
+    for (const file of walk(absoluteRoot)) {
+      const extension = path.extname(file);
+      if (!sourceExtensions.has(extension)) continue;
+      checkSourceFile(file);
+    }
+  }
+}
+
+function checkSourceFile(file) {
+  const content = readFileSync(file, 'utf8');
+  const relative = path.relative(root, file);
+  const isTokenFile = hasPathFragment(file, tokenPathFragments);
+  const allowsRuntimeVariable = hasPathFragment(file, runtimeVariablePathFragments);
+
+  content.split(/\r?\n/).forEach((line, index) => {
+    const location = `${relative}:${index + 1}`;
+    if ((file.endsWith('.jsx') || file.endsWith('.tsx')) && inlineStylePattern.test(line)) {
+      errors.push(`${location}: avoid inline style=; use Panda recipes, recipe variants, or data attributes`);
+    }
+    if (!isTokenFile && rawColorPattern.test(line)) {
+      errors.push(`${location}: raw color found; move repeated colors to Panda tokens or semantic tokens`);
+    }
+    if (
+      !isTokenFile &&
+      !allowsRuntimeVariable &&
+      cssVariablePattern.test(line) &&
+      !line.includes('pandacss-allow-runtime-var')
+    ) {
+      errors.push(`${location}: direct CSS variable reference found outside token/theme/runtime allowlisted files`);
+    }
+  });
+}
+
+function* walk(directory) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (hasPathFragment(absolute, ignoredPathFragments)) continue;
+      yield* walk(absolute);
+    } else if (entry.isFile()) {
+      yield absolute;
+    }
+  }
+}
+
+function hasPathFragment(file, fragments) {
+  const normalized = path.normalize(file);
+  const normalizedWithTrailingSeparator = normalized.endsWith(path.sep) ? normalized : `${normalized}${path.sep}`;
+  return fragments.some((fragment) => {
+    const normalizedFragment = path.normalize(fragment);
+    return normalized.includes(normalizedFragment) || normalizedWithTrailingSeparator.includes(normalizedFragment);
+  });
+}

--- a/config/claudius/skills/setup-pandacss/assets/pre-commit-hooks.yaml.template
+++ b/config/claudius/skills/setup-pandacss/assets/pre-commit-hooks.yaml.template
@@ -1,0 +1,8 @@
+- repo: local
+  hooks:
+    - id: pandacss-practices
+      name: PandaCSS practice guardrails
+      entry: node scripts/check-pandacss-practices.mjs
+      language: system
+      files: \.(js|jsx|ts|tsx|css|mdx)$|panda\.config\.|(^|/)package\.json$
+      pass_filenames: false

--- a/config/claudius/skills/setup-pandacss/instructions.md
+++ b/config/claudius/skills/setup-pandacss/instructions.md
@@ -1,0 +1,249 @@
+# Setup PandaCSS
+
+Set up or harden PandaCSS for a React/TypeScript frontend, especially a React Router 7 + Vite app.
+
+This skill is based on practices proven useful in a React Router 7 admin-console refactor:
+
+- Generate `styled-system/` as a build-time artifact, not hand-written code.
+- Use semantic tokens, recipes, slot recipes, and `styled-system/jsx` for reusable UI.
+- Keep route-level `css()` usage static, token-backed, and local to page layout.
+- Use explicit CSS cascade layers and React Router-compatible stylesheet loading.
+- Add check-only enforcement for inline styles, raw colors, and missing Panda config basics.
+
+## Prerequisites
+
+- The project must have a `package.json`.
+- The project should be React, React Router, Vite, Storybook, or another JS/TS frontend that can run PandaCSS.
+- `node` must be available where hooks run.
+- If the project uses Nix Flakes and git-hooks.nix, ensure `/setup-git-hooks` has already been applied.
+- If the project needs JS/TS linting or type checking, compose this skill with `/setup-biome` and `/setup-ts-typecheck`.
+
+## Steps
+
+### 1. Identify the app mode
+
+Detect the frontend shape before editing:
+
+| Evidence | Mode | Styling integration |
+|---|---|---|
+| `vite.config.*`, `createBrowserRouter`, `RouterProvider` | React Router Data/SPA mode on Vite | Import one root CSS file from the client entry (`src/main.tsx`, `src/entry.client.tsx`, etc.) |
+| `react-router.config.*`, `@react-router/dev`, route modules with `links` exports | React Router Framework mode | Expose CSS through route/root `links` using Vite `?url` imports |
+| Storybook config under `.storybook/` | Component catalog | Include Storybook stories in Panda extraction when stories call Panda APIs |
+
+Do not convert routing mode as part of this skill. Only adapt PandaCSS to the app mode that already exists.
+
+### 2. Install PandaCSS dependencies
+
+Check `package.json`.
+
+Required dev dependency:
+
+- `@pandacss/dev`
+
+Optional dependencies, only if the project already uses or wants them:
+
+- `@park-ui/panda-preset`
+- `@ark-ui/react`
+
+Add package-manager commands using the project's existing manager. Do not switch package managers.
+
+Examples:
+
+```bash
+pnpm add -D @pandacss/dev
+pnpm add @ark-ui/react
+pnpm add -D @park-ui/panda-preset
+```
+
+For Nix Flake projects, verify `pkgs.nodejs` is listed in `devShells.default.packages` or an
+equivalent dev-shell package list. If it is missing, add it before wiring the `pandacss-practices`
+hook. The practice checker runs with `node scripts/check-pandacss-practices.mjs`, so the hook must
+not depend on an unpinned host Node installation.
+
+### 3. Add or normalize Panda config
+
+Create or update `panda.config.ts`.
+
+Required baseline:
+
+```ts
+import { defineConfig } from '@pandacss/dev';
+
+const isStorybook = process.env['STORYBOOK'] === 'true';
+
+export default defineConfig({
+  strictTokens: true,
+  preflight: true,
+  include: ['./src/**/*.{ts,tsx}'].concat(isStorybook ? './.storybook/**/*.{ts,tsx}' : []),
+  exclude: [],
+  outdir: 'styled-system',
+  jsxFramework: 'react',
+});
+```
+
+Adjust rather than blindly overwrite:
+
+- Keep `strictTokens: true` unless the migration is explicitly staged and the user accepts temporary looseness.
+- Set `preflight` deliberately. Prefer `true` for new Panda-first apps; preserve an existing reset only when changing it would be a larger visual migration.
+- Keep `include` aligned with every route, component, and Storybook file that calls Panda APIs.
+- Use `conditions` for theme/data-state selectors that repeat across components.
+- Keep `globalCss` minimal: `html`, `body`, `#root`, color mode, font smoothing, and unavoidable browser defaults only.
+- Add `staticCss` for recipe variants that are chosen at runtime and cannot be seen by Panda extraction.
+- Keep generated output in one place, normally `styled-system/`, and configure TypeScript/Vite aliases for it.
+
+### 4. Add CSS entry and cascade layers
+
+Use exactly one root stylesheet for Panda layers.
+
+For Vite SPA/Data mode:
+
+1. Create or update a root CSS file such as `src/App.css`.
+2. Import it once from the app entry.
+3. Keep Panda layer order explicit:
+
+```css
+@layer reset, third-party, base, tokens, recipes, utilities;
+```
+
+Include third-party layers only when needed. Panda's own relative order must remain:
+
+```text
+reset -> base -> tokens -> recipes -> utilities
+```
+
+For React Router Framework mode:
+
+1. Import CSS URLs with Vite `?url`.
+2. Return them from `links` in the root or route module.
+
+```tsx
+import appStylesHref from './App.css?url';
+
+export const links = () => [{ rel: 'stylesheet', href: appStylesHref }];
+```
+
+Do not inject stylesheets imperatively in React components or loaders.
+
+### 5. Add generated-system aliases
+
+Update TypeScript and Vite aliases when missing.
+
+`tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "styled-system/*": ["./styled-system/*"]
+    }
+  },
+  "include": ["src", "styled-system", "panda.config.ts"]
+}
+```
+
+`vite.config.ts`:
+
+```ts
+resolve: {
+  alias: {
+    'styled-system': resolve(rootDir, 'styled-system'),
+  },
+},
+```
+
+Preserve existing aliases and path configuration.
+
+### 6. Add scripts
+
+Add scripts without overwriting existing names:
+
+```json
+{
+  "scripts": {
+    "panda:codegen": "panda codegen",
+    "panda:codegen:watch": "panda codegen --watch",
+    "panda:practices": "node scripts/check-pandacss-practices.mjs"
+  }
+}
+```
+
+If `styled-system/` is ignored, CI and local setup must run `panda:codegen` before type checking,
+tests, Storybook, and production builds.
+
+### 7. Add practice enforcement
+
+Copy [panda-practices-check.mjs.template](assets/panda-practices-check.mjs.template) to:
+
+```text
+scripts/check-pandacss-practices.mjs
+```
+
+Then add either hook template when the project uses that backend:
+
+- Nix git-hooks.nix: [hooks.nix.template](assets/hooks.nix.template)
+- Pre-commit local hooks: [pre-commit-hooks.yaml.template](assets/pre-commit-hooks.yaml.template)
+
+The check is intentionally narrow and check-only. It fails on:
+
+- Missing `panda.config.*`
+- Missing `strictTokens: true`
+- Missing `jsxFramework: 'react'`
+- Missing `panda:codegen`
+- Inline `style=` in JSX/TSX
+- Raw hex/RGB/HSL colors outside token/theme files
+- `var(--...)` references outside token/theme/global style files or explicitly allowlisted runtime-var files
+
+If a project legitimately needs measured runtime layout, prefer setting a CSS variable on a wrapper and consuming it
+from a Panda recipe or slot recipe. If that is still too strict, add a small project-specific allowlist to the script
+instead of weakening the whole policy. For narrow one-off runtime variables, add an inline
+`pandacss-allow-runtime-var` comment with a short rationale.
+
+The checker accepts comma-separated env overrides for narrow project differences:
+
+- `PANDACSS_CHECK_ROOTS`
+- `PANDACSS_CHECK_TOKEN_PATHS`
+- `PANDACSS_CHECK_RUNTIME_VAR_PATHS`
+- `PANDACSS_CHECK_IGNORE_PATHS`
+
+### 8. Use Panda idioms in code changes
+
+Apply these implementation rules during migration:
+
+- Put reusable component visuals in `cva`, `sva`, or `styled-system/jsx` components.
+- Use `sva` for multi-part components such as Sidebar, Page, Field, Table, DataList, and ToggleSwitch.
+- Use `cva` for single-slot components such as Button, Text, Heading, Input, Textarea, Card, and Message.
+- Reserve `css()` and layout patterns such as `flex`, `grid`, `hstack`, and `vstack` for route-local layout.
+- Prefer semantic tokens (`fg`, `fg.muted`, `bg.panel`, `border`, `primary`) over palette tokens.
+- Use bracket escape values only for intentional one-offs, and prefer to move repeated values into tokens.
+- Do not use React Router loaders/actions for styling side effects; derive visual state in components from loader data,
+  navigation state, action results, data attributes, or recipe variants.
+- Keep Storybook using the same root CSS and color-mode attributes as the app.
+
+### 9. Validate
+
+Run the strongest available local loop:
+
+```bash
+pnpm panda:codegen
+pnpm panda:practices
+pnpm typecheck
+pnpm test:run
+pnpm build
+pnpm build-storybook
+```
+
+If the project uses a different package manager, translate the commands without changing script names.
+
+For UI migrations, also inspect Storybook or run visual regression tests when available.
+
+## Important Notes
+
+- Do not commit `styled-system/` when the project intentionally ignores generated output. Document and enforce codegen
+  instead.
+- Do not rely on Panda extraction for runtime-constructed token names, class names, or variant values. Use recipe variants,
+  data attributes, CSS variables, or `staticCss`.
+- Do not add large global CSS files to compensate for missing recipes. Global CSS is the exception path.
+- Do not remove existing CSS frameworks in the same change unless the user explicitly asked for a full migration.
+- Do not suppress the practice checker with broad path exclusions. Prefer fixing components or adding narrow allowlist
+  comments/paths with a short rationale.

--- a/config/claudius/skills/setup-pandacss/skill.yaml
+++ b/config/claudius/skills/setup-pandacss/skill.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: setup-pandacss
+description: Set up or harden PandaCSS for React, React Router 7, Vite, and
+  Storybook projects. Use when adding PandaCSS, migrating from ad hoc CSS or
+  inline styles to Panda recipes/tokens, or enforcing PandaCSS practices in a
+  TypeScript frontend.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: "(no arguments required)"
+  codex:
+    invocation: manual

--- a/config/claudius/skills/setup-quality-profile/references/tofu-infra.md
+++ b/config/claudius/skills/setup-quality-profile/references/tofu-infra.md
@@ -87,13 +87,39 @@ The infrastructure baseline should include:
 - `tfsec`
 - `trivy config`
 
+Provider and module hygiene:
+
+- Track `.terraform.lock.hcl` for every root module that is validated or applied.
+- Use bounded provider constraints such as `~> 6.30.0` or `>= 6.30.0, < 7.0.0`; avoid bare
+  `>=` constraints in mature infrastructure repositories.
+- Keep OpenTofu/Terraform itself exactly pinned through the Nix flake or equivalent toolchain lock.
+- Make validation backend-free and credential-free where possible; providers should not contact
+  real cloud APIs during static validation.
+- Prefer root-module layout that lets CI discover and validate every independently applied unit.
+
 ## CI Policy
 
 - Use `fetch-depth: 0` in lint workflows.
-- Run `tflint --init` before `pre-commit` when `tflint` is enabled.
-- Skip `tofu-validate-no-backend` in CI only when provider initialization is not feasible there.
-  When skipped, document the reason inline next to `SKIP`.
+- Run `tflint --init` inside the project dev shell before `pre-commit` when `tflint` is enabled
+  (for example `nix develop -c tflint --init`).
+- The lint workflow should run the same hook set as the local quality loop. Do not skip
+  `tofu-validate-no-backend` for pure IaC repositories unless a concrete external dependency
+  remains after attempting backend-free validation. When skipped, document the reason inline next
+  to `SKIP`.
+- Run `pre-commit` with `--show-diff-on-failure` so formatting drift is visible in CI logs.
 - Keep commitlint and PR-title lint in the same `CI - Lint` workflow.
+- Use minimal workflow permissions. Repo-wide lint normally needs only `contents: read`.
+- Pin GitHub Actions by full commit SHA in mature infrastructure repositories. Keep the intended
+  semantic tag (`v4`, `v3`, etc.) in a comment and re-resolve it explicitly during upgrades.
+
+## Delivery Policy
+
+- Separate "update deployment manifest", "validate CI", and "apply infrastructure" into distinct
+  gates when the repository is used by customers or MVP environments.
+- If a workflow both commits desired-state changes and applies them, document the residual risk and
+  ensure the workflow cannot bypass the same lint and validation checks expected for pull requests.
+- Apply jobs that assume cloud roles need explicit `id-token: write`; validation jobs should not
+  inherit that permission.
 
 ## Required Checks
 

--- a/config/claudius/skills/setup-tofu-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-tofu-lint/assets/hooks.nix.template
@@ -17,23 +17,68 @@ tofu-validate-no-backend = {
         #!/usr/bin/env bash
         set -euo pipefail
         temp_cli_config="$(mktemp)"
-        trap 'rm -f "$temp_cli_config"' EXIT
+        temp_data_root="$(mktemp -d)"
+        trap 'rm -rf "$temp_cli_config" "$temp_data_root"' EXIT
         export TF_CLI_CONFIG_FILE="$temp_cli_config"
+        export TF_IN_AUTOMATION=true
         export AWS_EC2_METADATA_DISABLED=true
-        for arg in "$@"; do
-          dirname "$arg"
-        done \
-          | sort \
-          | uniq \
-          | while read -r dir; do
-              ${pkgs.opentofu}/bin/tofu -chdir="$dir" init -backend=false
-              ${pkgs.opentofu}/bin/tofu -chdir="$dir" validate
-            done
+        export CHECKPOINT_DISABLE=true
+        root_list_file="''${TOFU_VALIDATE_ROOTS_FILE:-.tofu-root-modules}"
+        if [ ! -f "$root_list_file" ]; then
+          mapfile -t tf_files < <(
+            ${pkgs.findutils}/bin/find . \
+              -name '*.tf' \
+              -not -path '*/.terraform/*' \
+              -print
+          )
+          if [ "''${#tf_files[@]}" -gt 0 ] && [ "''${TOFU_VALIDATE_ALLOW_NO_LOCKED_ROOTS:-}" != "1" ]; then
+            echo "tofu-validate-no-backend: found .tf files but no $root_list_file root-module list." >&2
+            echo "Create $root_list_file with one root module directory per line and commit provider lock files for each root." >&2
+            echo "Set TOFU_VALIDATE_ALLOW_NO_LOCKED_ROOTS=1 only for module-only repositories with a separate validation harness." >&2
+            exit 1
+          fi
+          echo "tofu-validate-no-backend: no root-module list found; skipping."
+          exit 0
+        fi
+
+        mapfile -t root_dirs < <(
+          ${pkgs.gnugrep}/bin/grep -Ev '^[[:space:]]*(#|$)' "$root_list_file" \
+            | ${pkgs.gnused}/bin/sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' \
+            | ${pkgs.gnugrep}/bin/grep -Ev '^[[:space:]]*$' \
+            || true
+        )
+        if [ "''${#root_dirs[@]}" -eq 0 ]; then
+          echo "tofu-validate-no-backend: $root_list_file contains no root module directories." >&2
+          exit 1
+        fi
+        missing_lock_dirs=()
+        for dir in "''${root_dirs[@]}"; do
+          if [ ! -d "$dir" ]; then
+            echo "tofu-validate-no-backend: root module directory does not exist: $dir" >&2
+            exit 1
+          fi
+          if [ ! -f "$dir/.terraform.lock.hcl" ]; then
+            missing_lock_dirs+=("$dir")
+          fi
+        done
+        if [ "''${#missing_lock_dirs[@]}" -gt 0 ]; then
+          echo "tofu-validate-no-backend: root modules are missing .terraform.lock.hcl:" >&2
+          for dir in "''${missing_lock_dirs[@]}"; do
+            echo "- $dir" >&2
+          done
+          exit 1
+        fi
+        for dir in "''${root_dirs[@]}"; do
+          data_dir="$(mktemp -d "$temp_data_root/tfdata.XXXXXX")"
+          TF_DATA_DIR="$data_dir" ${pkgs.opentofu}/bin/tofu -chdir="$dir" init -backend=false -lockfile=readonly
+          TF_DATA_DIR="$data_dir" ${pkgs.opentofu}/bin/tofu -chdir="$dir" validate
+        done
       '';
     in
     "${tofu-validate}/bin/tofu-validate-no-backend";
-  files = "\\.(tf(vars)?|terraform\\.lock\\.hcl)$";
+  files = "(^|/)\\.tofu-root-modules$|\\.(tf(vars)?|terraform\\.lock\\.hcl)$";
   excludes = [ "\\.terraform/.*$" ];
+  pass_filenames = false;
   require_serial = true;
 };
 hclfmt = {

--- a/config/claudius/skills/setup-tofu-lint/instructions.md
+++ b/config/claudius/skills/setup-tofu-lint/instructions.md
@@ -17,15 +17,50 @@ Hooks added:
 - **tofu-format** — Runs `tofu fmt` on `.tf` and `.tfvars` files
 - **hclfmt** — Formats `.hcl` files (e.g. `.terraform.lock.hcl`, Packer configs)
 - **tflint** — Terraform/OpenTofu linter for best practices and errors
-- **tofu-validate-no-backend** — Runs `tofu init -backend=false` then `tofu validate` per directory (skips `.terraform/` dirs). Runs serially to avoid init conflicts.
+- **tofu-validate-no-backend** — Reads root module directories from `.tofu-root-modules`, requires each root to have `.terraform.lock.hcl`, then runs `tofu init -backend=false -lockfile=readonly` and `tofu validate` for each root module. Runs serially to avoid init conflicts.
 - **terraform-validate** — Explicitly disabled (replaced by tofu-validate-no-backend)
 
 ### 2. Ensure `pkgs.opentofu` is available
 
 The hooks reference `pkgs.opentofu` for tofu-format and tofu-validate-no-backend. Most packages are pulled in via `pre-commit-check.enabledPackages`, but verify that `opentofu` is accessible. If the project already has `opentofu` in its packages, no action needed.
 
+### 3. Declare root modules and check provider reproducibility
+
+For each root module that CI validates or production applies:
+
+- Add the root module directory to `.tofu-root-modules`, one path per line. Use `.` for a single
+  root at the repository root. Blank lines and `#` comments are allowed.
+- Track `.terraform.lock.hcl`.
+- Prefer bounded provider constraints (`~>` or explicit upper bounds) over bare `>=`.
+- Keep OpenTofu itself pinned by the flake/toolchain rather than relying on host state.
+- Verify `TF_DATA_DIR=<temp-dir> tofu init -backend=false -lockfile=readonly && tofu validate` works
+  without cloud credentials or cached local backend state.
+
+If a project is new and has no provider lock file yet, initialize it intentionally once and commit the
+lock file before enabling the hook as a required gate. Do not list a root module until its lock file
+is committed.
+
+Reusable modules should normally be validated through one or more locked root modules that consume
+them. Do not run `tofu init -lockfile=readonly` directly in module-only directories unless they have
+their own committed lock file or a dedicated validation harness.
+
+If a repository intentionally contains only reusable modules and validates them elsewhere, set
+`TOFU_VALIDATE_ALLOW_NO_LOCKED_ROOTS=1` on the `tofu-validate-no-backend` hook with an inline comment
+explaining the external validation path. Do not use this escape hatch for repositories with root
+modules that should have committed provider locks.
+
 ## Important Notes
 
 - Do NOT remove or modify any existing hooks.
+- The `tofu-validate-no-backend` hook uses `pass_filenames = false` so module-only changes still
+  validate the repository's locked root modules instead of trying to initialize reusable module
+  directories directly.
+- The hook fails when `.tf` files exist but `.tofu-root-modules` is missing, unless
+  `TOFU_VALIDATE_ALLOW_NO_LOCKED_ROOTS=1` is explicitly set for a module-only repository.
+- The hook fails when a directory listed in `.tofu-root-modules` is missing or lacks
+  `.terraform.lock.hcl`.
 - The `tofu-validate-no-backend` hook uses `require_serial = true` because `tofu init` can conflict when run in parallel across directories.
-- The hook sets `AWS_EC2_METADATA_DISABLED=true` and uses a temporary `TF_CLI_CONFIG_FILE` to avoid interference with real backends during validation.
+- The hook sets `AWS_EC2_METADATA_DISABLED=true` and uses temporary `TF_CLI_CONFIG_FILE` and
+  `TF_DATA_DIR` values to avoid interference from real backends or cached local `.terraform` state
+  during validation.
+- Validation hooks should be check-only gates. They may create local `.terraform` working data, but should not rewrite provider locks during CI.

--- a/config/claudius/skills/setup-tofu-lint/skill.yaml
+++ b/config/claudius/skills/setup-tofu-lint/skill.yaml
@@ -1,7 +1,8 @@
 version: 1
 name: setup-tofu-lint
 description: Set up OpenTofu/Terraform lint and format hooks (tofu fmt, hclfmt, tflint,
-  tofu validate) in a Nix flake project. Use when adding OpenTofu code quality checks.
+  backend-free tofu validate) in a Nix flake project. Use when adding reproducible
+  OpenTofu code quality checks with provider locks and bounded provider constraints.
 targets:
   claude-code:
     invocation: manual

--- a/config/claudius/skills/setup-tofu-project/instructions.md
+++ b/config/claudius/skills/setup-tofu-project/instructions.md
@@ -35,6 +35,10 @@ Add commitlint with Conventional Commits rules, git hooks, and CI enforcement us
 ### Step 9: `/setup-nix-ci-lint`
 Generate `.github/workflows/lint.yml` from the flake.nix hook configuration using Determinate Systems actions.
 
+### Step 10: `/setup-github-guardrails tofu-infra`
+Normalize workflow names, job names, permissions, required-check recommendations, and Action pinning
+against the OpenTofu infrastructure profile.
+
 ## After Completion
 
 Summarize what was set up and list any config files the user needs to create:
@@ -44,9 +48,17 @@ Summarize what was set up and list any config files the user needs to create:
 
 Only list files that do not already exist in the project root.
 
+Also summarize any remaining reproducibility gaps:
+- root modules missing `.terraform.lock.hcl`
+- provider constraints with no upper bound
+- lint workflows that skip local hooks in CI
+- GitHub Actions left on mutable tag references
+- deploy/apply workflows that bypass the required lint gate
+
 ## Important Notes
 
 - Each step is idempotent — if hooks or config already exist, they are skipped, not duplicated.
 - The execution order matters: `setup-git-hooks` must run first as all other skills depend on it.
-- `/setup-nix-ci-lint` must run last because it reads the final hook configuration to generate CI.
+- `/setup-nix-ci-lint` must run after all hooks are in place because it reads the final hook configuration to generate CI.
+- `/setup-github-guardrails` must run after workflows exist so it can normalize the hosted enforcement surface.
 - This skill is designed for OpenTofu IaC projects. For application projects with different language tooling, use the individual skills selectively instead.

--- a/flake.nix
+++ b/flake.nix
@@ -427,6 +427,14 @@
           };
           lintHooks = {
             actionlint.enable = true;
+            claudius-skill-guardrails = {
+              enable = true;
+              name = "claudius-skill-guardrails";
+              entry = "${pkgs.python3}/bin/python3 scripts/test-claudius-skills.py";
+              language = "system";
+              pass_filenames = false;
+              files = "^config/claudius/skills/|^scripts/test-claudius-skills\\.py$";
+            };
             deadnix = {
               enable = true;
               settings = {

--- a/scripts/test-claudius-skills.py
+++ b/scripts/test-claudius-skills.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Regression checks for Claudius skill guardrail invariants."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def check_contains(errors: list[str], relative_path: str, needle: str) -> None:
+    if needle not in read(relative_path):
+        errors.append(f"{relative_path}: missing expected text: {needle!r}")
+
+
+def check_not_contains(errors: list[str], relative_path: str, needle: str) -> None:
+    if needle in read(relative_path):
+        errors.append(f"{relative_path}: forbidden text is present: {needle!r}")
+
+
+def check_not_regex(errors: list[str], relative_path: str, pattern: str) -> None:
+    if re.search(pattern, read(relative_path), flags=re.MULTILINE):
+        errors.append(f"{relative_path}: forbidden pattern matched: {pattern}")
+
+
+def check_uses_are_sha_pinned(errors: list[str], relative_path: str) -> None:
+    action_refs = re.findall(
+        r"^\s*uses:\s*([^\s#]+)",
+        read(relative_path),
+        flags=re.MULTILINE,
+    )
+    for uses in action_refs:
+        if uses.startswith("./"):
+            continue
+        if "@" not in uses:
+            errors.append(f"{relative_path}: action is not versioned: {uses}")
+            continue
+        _action, ref = uses.rsplit("@", 1)
+        if not re.fullmatch(r"[0-9a-f]{40}", ref):
+            errors.append(f"{relative_path}: action is not pinned by full SHA: {uses}")
+
+
+def check_ci_skill(errors: list[str]) -> None:
+    ci_template = "config/claudius/skills/setup-nix-ci-lint/assets/lint.yml.template"
+    check_uses_are_sha_pinned(errors, ci_template)
+    check_contains(errors, ci_template, "contents: read")
+    check_contains(errors, ci_template, "--show-diff-on-failure")
+    check_not_contains(errors, ci_template, "id-token: write")
+    check_not_contains(errors, ci_template, "SKIP:")
+    check_not_regex(errors, ci_template, r"uses:\s+[^@\s]+@v\d+")
+
+    ci_instructions = "config/claudius/skills/setup-nix-ci-lint/instructions.md"
+    check_contains(errors, ci_instructions, "`tflint` | `nix develop -c tflint --init`")
+    check_contains(errors, ci_instructions, "Do not skip hooks in CI by default.")
+    check_contains(errors, ci_instructions, "`pre-commit-check.enabledPackages`")
+    check_not_contains(errors, ci_instructions, "nix run nixpkgs#tflint -- --init")
+    check_not_contains(
+        errors,
+        ci_instructions,
+        "Requires `tofu init` which may need provider credentials",
+    )
+
+
+def check_tofu_skill(errors: list[str]) -> None:
+    tofu_hook = "config/claudius/skills/setup-tofu-lint/assets/hooks.nix.template"
+    check_contains(errors, tofu_hook, 'temp_data_root="$(mktemp -d)"')
+    check_contains(errors, tofu_hook, "TF_DATA_DIR=\"$data_dir\"")
+    check_contains(errors, tofu_hook, "TF_IN_AUTOMATION=true")
+    check_contains(errors, tofu_hook, "CHECKPOINT_DISABLE=true")
+    check_contains(errors, tofu_hook, ".terraform.lock.hcl")
+    check_contains(errors, tofu_hook, ".tofu-root-modules")
+    check_contains(errors, tofu_hook, "(^|/)\\\\.tofu-root-modules$")
+    check_contains(errors, tofu_hook, "init -backend=false -lockfile=readonly")
+    check_contains(errors, tofu_hook, "pass_filenames = false")
+    check_contains(errors, tofu_hook, "TOFU_VALIDATE_ROOTS_FILE")
+    check_contains(errors, tofu_hook, "TOFU_VALIDATE_ALLOW_NO_LOCKED_ROOTS")
+    check_contains(errors, tofu_hook, "missing .terraform.lock.hcl")
+    check_not_contains(errors, tofu_hook, 'dirname "$arg"')
+    check_not_contains(
+        errors,
+        tofu_hook,
+        "find . \\\n            -name '.terraform.lock.hcl'",
+    )
+    check_not_regex(errors, tofu_hook, r"init -backend=false(?! -lockfile=readonly)")
+
+    formatter = "config/claudius/skills/setup-nix-lint/assets/formatter.nix.template"
+    check_contains(errors, formatter, 'git ls-files -- "$@"')
+    check_not_contains(errors, formatter, 'exec ${pkgs.nixfmt}/bin/nixfmt "$@"')
+
+
+def check_profile_policy(errors: list[str]) -> None:
+    tofu_profile = (
+        "config/claudius/skills/setup-quality-profile/references/tofu-infra.md"
+    )
+    check_contains(errors, tofu_profile, "Use bounded provider constraints")
+    check_contains(errors, tofu_profile, "Do not skip")
+    check_contains(errors, tofu_profile, "Pin GitHub Actions by full commit SHA")
+    check_contains(errors, tofu_profile, "Separate \"update deployment manifest\"")
+
+    guardrails = "config/claudius/skills/setup-github-guardrails/instructions.md"
+    check_contains(errors, guardrails, "full commit SHA")
+    check_contains(
+        errors,
+        guardrails,
+        "git ls-remote https://github.com/<owner>/<repo>.git 'refs/tags/<tag>^{}'",
+    )
+    check_contains(errors, guardrails, "If the peeled ref is absent")
+
+    local_loop = "config/claudius/skills/setup-local-quality-loop/instructions.md"
+    check_contains(errors, local_loop, "CI does not skip local hooks by default")
+
+    tofu_project = "config/claudius/skills/setup-tofu-project/instructions.md"
+    check_contains(errors, tofu_project, "`/setup-github-guardrails tofu-infra`")
+    check_contains(
+        errors,
+        tofu_project,
+        "GitHub Actions left on mutable tag references",
+    )
+
+
+def check_pandacss_skill(errors: list[str]) -> None:
+    skill = "config/claudius/skills/setup-pandacss/skill.yaml"
+    instructions = "config/claudius/skills/setup-pandacss/instructions.md"
+    checker = (
+        "config/claudius/skills/setup-pandacss/assets/"
+        "panda-practices-check.mjs.template"
+    )
+    nix_hook = "config/claudius/skills/setup-pandacss/assets/hooks.nix.template"
+    precommit_hook = (
+        "config/claudius/skills/setup-pandacss/assets/"
+        "pre-commit-hooks.yaml.template"
+    )
+
+    check_contains(errors, skill, "name: setup-pandacss")
+    check_contains(errors, skill, "React Router 7")
+    check_contains(errors, instructions, "strictTokens: true")
+    check_contains(errors, instructions, "jsxFramework: 'react'")
+    check_contains(errors, instructions, "styled-system/")
+    check_contains(errors, instructions, "React Router Framework mode")
+    check_contains(errors, instructions, "links")
+    check_contains(errors, instructions, "staticCss")
+    check_contains(errors, instructions, "`pkgs.nodejs`")
+    check_contains(errors, instructions, "node scripts/check-pandacss-practices.mjs")
+    check_contains(errors, instructions, "Do not rely on Panda extraction")
+    check_contains(errors, checker, "strictTokens")
+    check_contains(errors, checker, "inline style=")
+    check_contains(errors, checker, "raw color")
+    check_contains(errors, checker, "global.css")
+    check_contains(errors, instructions, "PANDACSS_CHECK_TOKEN_PATHS")
+    check_contains(errors, instructions, "PANDACSS_CHECK_RUNTIME_VAR_PATHS")
+    check_contains(errors, checker, "pandacss-allow-runtime-var")
+    check_contains(errors, nix_hook, "pandacss-practices")
+    check_contains(errors, precommit_hook, "pandacss-practices")
+    check_contains(errors, precommit_hook, "package\\.json")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    check_ci_skill(errors)
+    check_tofu_skill(errors)
+    check_profile_policy(errors)
+    check_pandacss_skill(errors)
+
+    if errors:
+        print("Claudius skill guardrail checks failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("Claudius skill guardrail checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- harden the OpenTofu infrastructure setup skills and guard their invariants
- add a PandaCSS setup skill for Claudius-managed skills
- keep the branch scoped to Claudius skill improvements after splitting the Elvish fix out

## Testing
- pre-push hooks passed during `git push -u origin feat/claudius-skills`