### PR TITLE
fix(elvish): avoid eval-time direnv hook read

### DIFF
--- a/config/home-manager/programs/elvish.nix
+++ b/config/home-manager/programs/elvish.nix
@@ -8,11 +8,9 @@ in
   xdg.configFile = {
 
     # Generate direnv integration module
-    "elvish/lib/direnv.elv".text = builtins.readFile (
-      pkgs.runCommand "direnv-elvish-hook" { } ''
-        ${pkgs.direnv}/bin/direnv hook elvish > $out
-      ''
-    );
+    "elvish/lib/direnv.elv".source = pkgs.runCommand "direnv-elvish-hook" { } ''
+      ${pkgs.direnv}/bin/direnv hook elvish > $out
+    '';
 
     # Local Atuin module patched for Elvish 0.21+
     "elvish/lib/atuin.elv".source = ./../../elvish/lib/atuin.elv;


### PR DESCRIPTION
## Summary
- avoid reading the direnv hook at Elvish evaluation time
- keep this unrelated Elvish fix separate from the Claudius skills branch

## Testing
- pre-push hooks passed during `git push -u origin fix/elvish-direnv-hook`