### PR TITLE
feat(claudius): harden shared skill guardrails

### DIFF
--- a/config/claudius/docs/skills/catalog.yaml
+++ b/config/claudius/docs/skills/catalog.yaml
@@ -16,9 +16,18 @@ categories:
   c-cpp:
     title: C / C++
     description: Formatting and static analysis for C-family projects.
+  haskell:
+    title: Haskell
+    description: Formatting, linting, and strict build checks for Haskell projects.
+  lean:
+    title: Lean
+    description: Lake build and lint checks for Lean projects.
   python:
     title: Python
     description: Python linting and strict type checking.
+  rust:
+    title: Rust
+    description: Rust formatting and strict Clippy checks.
   rails-ruby:
     title: Rails / Ruby
     description: Rails-oriented linting, security, typing, database safety, testing, and CI.
@@ -41,6 +50,15 @@ skills:
   setup-repository-baseline:
     category: foundation
     kind: bootstrap
+  setup-github-guardrails:
+    category: foundation
+    kind: building-block
+  setup-local-quality-loop:
+    category: foundation
+    kind: orchestrator
+  setup-quality-profile:
+    category: foundation
+    kind: orchestrator
   setup-nix-flake:
     category: foundation
     kind: bootstrap
@@ -80,14 +98,29 @@ skills:
   setup-ts-typecheck:
     category: frontend-typescript
     kind: building-block
+  setup-typed-eslint-monorepo:
+    category: frontend-typescript
+    kind: building-block
   setup-stylelint:
     category: frontend-typescript
     kind: building-block
   setup-c-lint:
     category: c-cpp
     kind: building-block
+  setup-haskell-lint:
+    category: haskell
+    kind: building-block
+  setup-lean-lint:
+    category: lean
+    kind: building-block
   setup-python-lint:
     category: python
+    kind: building-block
+  setup-rust-lint:
+    category: rust
+    kind: building-block
+  setup-ruby-lint:
+    category: rails-ruby
     kind: building-block
   setup-rubocop:
     category: rails-ruby
@@ -132,6 +165,9 @@ skills:
     category: iac-tofu
     kind: orchestrator
   setup-multicloud-iac-structure:
+    category: iac-tofu
+    kind: orchestrator
+  setup-google-workspace-iac:
     category: iac-tofu
     kind: orchestrator
   setup-sql-lint:

--- a/config/claudius/docs/skills/inventory.yaml
+++ b/config/claudius/docs/skills/inventory.yaml
@@ -111,6 +111,38 @@ skills:
       This is the source-of-truth policy surface for repository collaboration.
       Hosted enforcement and local hooks should compose around it, not replace it.
 
+  setup-github-guardrails:
+    topic: foundation
+    role: orchestrator
+    exposure: primary
+    future_action: keep-as-hosted-policy-layer
+    successor: []
+    rationale: >-
+      Hosted enforcement is the durable policy surface for workflow naming,
+      required checks, permissions, and PR-title lint. It should remain aligned
+      with repository profiles and compose with the local quality loop.
+
+  setup-local-quality-loop:
+    topic: foundation
+    role: orchestrator
+    exposure: primary
+    future_action: keep-as-local-ci-feedback-layer
+    successor: []
+    rationale: >-
+      This skill coordinates local hooks, commitlint, and repo-wide lint CI for a
+      chosen repository profile. It should stay separate from hosted GitHub policy
+      while sharing the same naming and check contract.
+
+  setup-quality-profile:
+    topic: foundation
+    role: orchestrator
+    exposure: primary
+    future_action: keep-as-profile-entry-point
+    successor: []
+    rationale: >-
+      This is the profile-level entry point that composes repository governance,
+      local quality loops, hosted guardrails, and stack-specific lint skills.
+
   setup-nix-flake:
     topic: foundation
     role: substrate
@@ -255,6 +287,17 @@ skills:
     rationale: >-
       Type checking is a clean reusable unit and still useful independently.
 
+  setup-typed-eslint-monorepo:
+    topic: frontend-typescript
+    role: building-block
+    exposure: primary
+    future_action: keep-standalone-and-compose-into-js-baselines
+    successor: []
+    rationale: >-
+      Typed ESLint remains necessary for framework-heavy, browser-extension,
+      GraphQL-aware, security-sensitive, or functional-rule-heavy TypeScript
+      surfaces that Biome alone should not replace.
+
   setup-stylelint:
     topic: frontend-typescript
     role: building-block
@@ -274,6 +317,26 @@ skills:
     rationale: >-
       A coherent language-specific building block with clear standalone value.
 
+  setup-haskell-lint:
+    topic: haskell
+    role: building-block
+    exposure: primary
+    future_action: keep-standalone-and-compose-into-polyglot-profile
+    successor: []
+    rationale: >-
+      Haskell formatting, HLint, and strict build checks are a coherent
+      language-specific quality surface for polyglot repositories.
+
+  setup-lean-lint:
+    topic: lean
+    role: building-block
+    exposure: primary
+    future_action: keep-standalone-and-compose-into-polyglot-profile
+    successor: []
+    rationale: >-
+      Lean/Lake quality checks are specific enough to stay standalone while
+      remaining available to the polyglot profile.
+
   setup-python-lint:
     topic: python
     role: building-block
@@ -283,6 +346,26 @@ skills:
     rationale: >-
       Strong standalone value today, while still fitting naturally inside a later
       Python project baseline.
+
+  setup-rust-lint:
+    topic: rust
+    role: building-block
+    exposure: primary
+    future_action: keep-standalone-and-compose-into-polyglot-profile
+    successor: []
+    rationale: >-
+      Cargo fmt and strict Clippy checks are a common reusable baseline for Rust
+      projects and polyglot repositories.
+
+  setup-ruby-lint:
+    topic: rails-ruby
+    role: building-block
+    exposure: primary
+    future_action: keep-standalone-and-compose-into-polyglot-profile
+    successor: []
+    rationale: >-
+      Generic Ruby RuboCop setup is useful outside Rails projects and should stay
+      separate from Rails-specific RuboCop policy.
 
   setup-rubocop:
     topic: rails-ruby
@@ -456,6 +539,18 @@ skills:
       concern that should be handled before project-specific OpenTofu quality gates.
       It standardizes stack state boundaries, global/regional splits, provider-native
       ownership paths, and deployment catalog placement across AWS, Azure, and GCP.
+
+  setup-google-workspace-iac:
+    topic: iac-tofu
+    role: orchestrator
+    exposure: primary
+    future_action: keep-as-primary-identity-iac-skill
+    successor: []
+    rationale: >-
+      Google Workspace and Cloud Identity need a dedicated identity-governance
+      IaC model separate from Google Cloud project infrastructure. This skill
+      covers Workspace state boundaries, group-management modes, credential
+      policy, and AWS federation separation.
 
   setup-sql-lint:
     topic: sql

--- a/config/claudius/skills/gemini-web-search/instructions.md
+++ b/config/claudius/skills/gemini-web-search/instructions.md
@@ -1,28 +1,33 @@
 # Gemini Web Search
 
-This command performs web searches using the Gemini CLI, which provides more accurate and up-to-date results than the built-in web search tool.
+Use Gemini CLI for web search only when the user explicitly asks to use Gemini
+or Gemini CLI. Do not claim it is more accurate than other available search
+tools.
 
 ## Prerequisites
 
-Before using this command:
-1. Ensure Gemini CLI is installed and configured
-2. Verify API credentials are properly set
-3. Check network connectivity
+Before searching:
+
+1. Verify `gemini` is available.
+2. Verify Gemini CLI can start with the current configuration.
+3. If credentials or local Gemini configuration are broken, report the concrete
+   startup error and stop.
 
 ## Search Process
 
-I will:
-- **Format your query** for optimal search results
-- **Execute search** via Gemini CLI command
-- **Parse results** to extract relevant information
-- **Present findings** in a structured format
-- **Cite sources** with proper attribution
+When the user provides a query:
+
+1. Format the query for search.
+2. Execute Gemini CLI in non-interactive mode.
+3. Parse the result for relevant claims and source links.
+4. Present findings with source attribution when Gemini returns sources.
 
 ## Query Format
 
 The command uses the following format:
+
 ```bash
-gemini --prompt "WebSearch: <your query>"
+gemini --prompt "WebSearch: <query>"
 ```
 
 ### Query Types
@@ -38,16 +43,11 @@ gemini --prompt "WebSearch: <your query>"
 - Add date constraints for time-sensitive information
 - Specify programming language or technology stack
 
-## Usage Instructions
+## Usage
 
-1. **Provide your search query** with clear intent
-
-2. **Specify any constraints**:
-   - Time range (e.g., "past year", "since 2024")
-   - Source preferences (e.g., "official docs only")
-   - Language or region
-
-3. **Review the results** and request refinement if needed
+If the user already provided a query, run the search. Ask a follow-up question
+only when the query is missing or the requested constraints are ambiguous enough
+to change the result materially.
 
 ## Example Queries
 
@@ -92,7 +92,3 @@ Results will include:
 - Some regions may have restricted access
 - Rate limits may apply for extensive searches
 - Real-time data may have slight delays
-
-## Ready to Search
-
-Please provide your search query and any specific requirements, and I'll execute it using the Gemini CLI for the most accurate results.

--- a/config/claudius/skills/gemini-web-search/skill.yaml
+++ b/config/claudius/skills/gemini-web-search/skill.yaml
@@ -1,3 +1,4 @@
 version: 1
 name: gemini-web-search
-description: Execute web searches using Gemini CLI instead of built-in web search
+description: Execute web searches with Gemini CLI when the user explicitly asks to
+  use Gemini or Gemini CLI for search.

--- a/config/claudius/skills/organize-context/instructions.md
+++ b/config/claudius/skills/organize-context/instructions.md
@@ -1,6 +1,7 @@
 # Context Document Organizer
 
-This command analyzes CLAUDE.md or AGENTS.md files and reorganizes them with complete, deduplicated rule references for optimal context management.
+Analyze `CLAUDE.md` or `AGENTS.md` files and reorganize them with complete,
+deduplicated rule references for optimal context management.
 
 ## Purpose
 
@@ -12,13 +13,31 @@ Context documents (CLAUDE.md, AGENTS.md) serve as primary guidance for AI agents
 
 This command ensures your context documents remain comprehensive and well-organized.
 
+## Target Discovery
+
+If the user provides a path, use it. Otherwise search the current repository for
+`CLAUDE.md` and `AGENTS.md`.
+
+- If exactly one candidate exists, use it.
+- If multiple candidates exist, ask the user which one to update.
+- If no candidate exists, ask whether to create `AGENTS.md` or `CLAUDE.md`.
+
+Use `config/claudius/rules` as the rules directory when it exists. Otherwise
+fall back to `/rules/` or a repository-local `rules/` directory.
+
+## Existing Configuration Policy
+
+Before changing an existing context document, present the intended
+reorganization approach and ask the user to confirm. Do not replace custom
+project sections unless the user approves that change.
+
 ## Analysis Process
 
-I will perform the following steps:
+Perform these steps:
 
 1. **Rule Discovery**
    - Parse the target document for all rule references
-   - Scan `/rules/` directory for all available rules
+   - Scan the selected rules directory for all available rules
    - Identify missing, outdated, or broken references
 
 2. **Content Analysis**
@@ -39,17 +58,13 @@ I will perform the following steps:
 
 ## Usage Instructions
 
-1. **Specify the target document**:
-   - Full path to CLAUDE.md or AGENTS.md
-   - Or simply "CLAUDE.md" for the current directory
-
-2. **Review the analysis report** showing:
+1. **Review the analysis report** showing:
    - Current structure assessment
    - Missing rule detections
    - Redundancy findings
    - Proposed reorganization plan
 
-3. **Approve the reorganization** to:
+2. **Approve the reorganization** to:
    - Update the document with optimized structure
    - Include all relevant rules
    - Remove duplications
@@ -137,7 +152,7 @@ Proposed Reorganization:
 ## Validation Checklist
 
 The reorganized document will ensure:
-- [ ] All rules in `/rules/` are considered for inclusion
+- [ ] All rules in the selected rules directory are considered for inclusion
 - [ ] No broken rule references remain
 - [ ] Related content is grouped logically
 - [ ] Hierarchical structure is consistent
@@ -145,12 +160,3 @@ The reorganized document will ensure:
 - [ ] Cross-references use current paths
 - [ ] Markdown formatting is standardized
 - [ ] Document remains concise yet complete
-
-## Ready to Organize
-
-Please provide:
-1. Path to the context document (CLAUDE.md or AGENTS.md)
-2. Preferred reorganization approach (minimal/comprehensive)
-3. Any specific rules that must be included or excluded
-
-I'll analyze the document and present a detailed reorganization plan for your approval.

--- a/config/claudius/skills/setup-biome/assets/biome.json.template
+++ b/config/claudius/skills/setup-biome/assets/biome.json.template
@@ -5,8 +5,13 @@
     "clientKind": "git",
     "useIgnoreFile": true
   },
-  "organizeImports": {
-    "enabled": true
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   },
   "formatter": {
     "enabled": true,
@@ -33,7 +38,6 @@
         "noUnusedImports": "error",
         "noUnusedVariables": "error",
         "noUnusedFunctionParameters": "warn",
-        "useArrayLiterals": "error",
         "useHookAtTopLevel": "error"
       },
       "suspicious": {
@@ -48,6 +52,7 @@
         "noNonNullAssertion": "warn",
         "useBlockStatements": "error",
         "useCollapsedElseIf": "error",
+        "useArrayLiterals": "error",
         "useConsistentArrayType": {
           "level": "error",
           "options": { "syntax": "shorthand" }
@@ -61,7 +66,10 @@
             "strictCase": true,
             "conventions": [
               { "selector": { "kind": "function" }, "formats": ["camelCase", "PascalCase"] },
-              { "selector": { "kind": "variable" }, "formats": ["camelCase", "PascalCase", "CONSTANT_CASE"] },
+              {
+                "selector": { "kind": "variable" },
+                "formats": ["camelCase", "PascalCase", "CONSTANT_CASE"]
+              },
               { "selector": { "kind": "typeLike" }, "formats": ["PascalCase"] }
             ]
           }
@@ -92,7 +100,7 @@
   },
   "overrides": [
     {
-      "include": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+      "includes": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/config/claudius/skills/setup-biome/instructions.md
+++ b/config/claudius/skills/setup-biome/instructions.md
@@ -4,6 +4,32 @@ Add Biome as the unified linter and formatter for JavaScript, TypeScript, JSX, T
 
 Biome replaces both ESLint and Prettier with a single tool. This skill configures the **strictest practical ruleset** suitable for production projects.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have a `package.json` in the root.
@@ -41,6 +67,12 @@ Create `biome.json` in the project root from [biome.json.template](assets/biome.
 
 If the version cannot be determined, omit the `$schema` field entirely rather than guessing.
 
+The template enables `vcs.useIgnoreFile`, so the repository must have a `.gitignore`.
+If `.gitignore` is missing, create an empty `.gitignore` before running Biome, or
+set `vcs.useIgnoreFile` to `false` and report that this weakens the baseline.
+Prefer creating `.gitignore`; do not leave the generated config in a state where
+`biome ci` fails before checking source files.
+
 ### 3. Verify strict configuration
 
 If `biome.json` already existed, verify the following settings are present. If any are missing or weaker, **do NOT overwrite** — inform the user of the discrepancies and let them decide.
@@ -51,9 +83,10 @@ Required settings:
 |---|---|---|
 | `linter.enabled` | `true` | Must not be disabled |
 | `formatter.enabled` | `true` | Must not be disabled |
-| `organizeImports.enabled` | `true` | Import ordering must be enforced |
+| `assist.actions.source.organizeImports` | `"on"` | Import ordering must be enforced |
 | `formatter.lineEnding` | `"lf"` | Unix line endings only |
-| `vcs.enabled` | `true` | Respect `.gitignore` |
+| `vcs.enabled` | `true` | Enable VCS integration |
+| `vcs.useIgnoreFile` | `true` when `.gitignore` exists | Respect `.gitignore`; requires the file to exist |
 | `linter.rules.recommended` | `true` | Baseline rule coverage |
 | `correctness.noUnusedImports` | `"error"` | Dead imports must not pass |
 | `correctness.noUnusedVariables` | `"error"` | Dead variables must not pass |

--- a/config/claudius/skills/setup-biome/skill.yaml
+++ b/config/claudius/skills/setup-biome/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-c-lint/assets/clang-tidy-check.sh.template
+++ b/config/claudius/skills/setup-c-lint/assets/clang-tidy-check.sh.template
@@ -10,9 +10,15 @@ if [[ ! -f "${compile_commands}" ]]; then
   exit 1
 fi
 
-if [[ "$#" -eq 0 ]]; then
-  echo "No input files provided to clang-tidy." >&2
-  exit 1
+files=("$@")
+if [[ ${#files[@]} -eq 0 ]]; then
+  mapfile -t files < <(
+    git ls-files '*.c' '*.cc' '*.cpp' '*.cxx' '*.h' '*.hh' '*.hpp' '*.hxx'
+  )
 fi
 
-exec clang-tidy -p "${build_dir}" "$@"
+if [[ ${#files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+exec clang-tidy -p "${build_dir}" "${files[@]}"

--- a/config/claudius/skills/setup-c-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-c-lint/assets/hooks.nix.template
@@ -1,2 +1,16 @@
-clang-format-check = mkHook "clang-format-check" "clang-format --dry-run --Werror";
-clang-tidy-check = mkHook "clang-tidy-check" "./scripts/clang-tidy-check.sh";
+clang-format-check = {
+  enable = true;
+  name = "clang-format-check";
+  entry = "clang-format --dry-run --Werror";
+  language = "system";
+  files = "\\.(c|cc|cpp|cxx|h|hh|hpp|hxx)$";
+  pass_filenames = true;
+};
+clang-tidy-check = {
+  enable = true;
+  name = "clang-tidy-check";
+  entry = "./scripts/clang-tidy-check.sh";
+  language = "system";
+  files = "\\.(c|cc|cpp|cxx|h|hh|hpp|hxx)$";
+  pass_filenames = true;
+};

--- a/config/claudius/skills/setup-c-lint/assets/pre-commit-hooks.yaml.template
+++ b/config/claudius/skills/setup-c-lint/assets/pre-commit-hooks.yaml.template
@@ -4,11 +4,11 @@
       name: clang-format check
       entry: clang-format --dry-run --Werror
       language: system
-      files: \.(c|h)$
+      files: \.(c|cc|cpp|cxx|h|hh|hpp|hxx)$
       pass_filenames: true
     - id: clang-tidy-check
       name: clang-tidy check
       entry: ./scripts/clang-tidy-check.sh
       language: system
-      files: \.(c|h)$
+      files: \.(c|cc|cpp|cxx|h|hh|hpp|hxx)$
       pass_filenames: true

--- a/config/claudius/skills/setup-c-lint/instructions.md
+++ b/config/claudius/skills/setup-c-lint/instructions.md
@@ -1,12 +1,40 @@
 # Setup C/C++ Lint
 
-Add clang-format and clang-tidy checks for `.c` and `.h` files. This skill enforces strict formatting and static analysis with check-only hooks.
+Add clang-format and clang-tidy checks for C and C++ source/header files (`.c`, `.cc`,
+`.cpp`, `.cxx`, `.h`, `.hh`, `.hpp`, `.hxx`). This skill enforces strict formatting and
+static analysis with check-only hooks.
 
 **The argument `$ARGUMENTS` is an optional list of `key=value` pairs**:
 
 - `build_dir`: Directory that contains `compile_commands.json` (default: `build`)
 
 If no argument is given, use the default above.
+
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
 
 ## Prerequisites
 
@@ -36,8 +64,8 @@ Add the hooks from [hooks.nix.template](assets/hooks.nix.template) into the `hoo
 
 Hooks added:
 
-- **clang-format-check** — Runs `clang-format --dry-run --Werror`
-- **clang-tidy-check** — Runs `./scripts/clang-tidy-check.sh`
+- **clang-format-check** — Runs `clang-format --dry-run --Werror` on C/C++ files
+- **clang-tidy-check** — Runs `./scripts/clang-tidy-check.sh` on C/C++ files
 
 #### A-2. Ensure clang tools are in the dev shell
 
@@ -55,27 +83,43 @@ Add the hooks from [pre-commit-hooks.yaml.template](assets/pre-commit-hooks.yaml
 
 Hooks added:
 
-- **clang-format-check** — Runs `clang-format --dry-run --Werror` on staged `.c`/`.h` files
-- **clang-tidy-check** — Runs `./scripts/clang-tidy-check.sh` on staged `.c`/`.h` files
+- **clang-format-check** — Runs `clang-format --dry-run --Werror` on staged C/C++ files
+- **clang-tidy-check** — Runs `./scripts/clang-tidy-check.sh` on staged C/C++ files
 
 ---
 
 ### 2. Create `.clang-format`
 
-Create `.clang-format` in the project root using the template in [clang-format.template](assets/clang-format.template).
+If `.clang-format` does not exist, create it in the project root using the
+template in [clang-format.template](assets/clang-format.template).
+
+If `.clang-format` already exists, inspect it and ask the user before changing
+it. Prefer preserving the existing style and only merge clearly missing baseline
+options when the user approves.
 
 ### 3. Create `.clang-tidy`
 
-Create `.clang-tidy` in the project root using the template in [clang-tidy.template](assets/clang-tidy.template).
+If `.clang-tidy` does not exist, create it in the project root using the
+template in [clang-tidy.template](assets/clang-tidy.template).
+
+If `.clang-tidy` already exists, inspect it and ask the user before changing it.
+Merge missing safety-critical checks without removing project-specific checks,
+warnings, or ignores.
 
 ### 4. Create `scripts/clang-tidy-check.sh`
 
-Create `scripts/clang-tidy-check.sh` using the template in [clang-tidy-check.sh.template](assets/clang-tidy-check.sh.template). Make it executable (`chmod +x`).
+If `scripts/clang-tidy-check.sh` does not exist, create it using the template in
+[clang-tidy-check.sh.template](assets/clang-tidy-check.sh.template). Make it
+executable (`chmod +x`).
+
+If the script already exists, inspect it and ask the user before replacing it.
+Prefer updating only the missing behavior needed by this skill.
 
 The script:
 
 - Requires `compile_commands.json` in `build_dir` (default: `build`)
 - Reads `CLANG_TIDY_BUILD_DIR` to override the build directory at runtime
+- Falls back to all git-tracked C/C++ files when invoked without file arguments
 
 ### 5. Ensure `compile_commands.json` exists
 

--- a/config/claudius/skills/setup-c-lint/skill.yaml
+++ b/config/claudius/skills/setup-c-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: '[build_dir=build]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-capybara-lint/instructions.md
+++ b/config/claudius/skills/setup-capybara-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Add rubocop-capybara to enforce best practices in system tests.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - RuboCop must be installed. If not, tell the user to run `/setup-rubocop` first.
@@ -18,11 +44,17 @@ gem 'rubocop-capybara', require: false
 
 ### 2. Add plugin to `.rubocop.yml`
 
-Add `rubocop-capybara` to the `plugins` list in `.rubocop.yml`.
+If `.rubocop.yml` does not exist, tell the user to run `/setup-rubocop` first.
+
+If `.rubocop.yml` exists, inspect it and ask the user before changing it. Add
+`rubocop-capybara` to the `plugins` list only if it is missing, and preserve the
+existing plugin order and project-specific RuboCop settings.
 
 ### 3. Add strict Capybara rules
 
-Append the following to `.rubocop.yml`:
+Ensure the following Capybara rules are present. If equivalent rules already
+exist, preserve the current values and ask the user before changing them. Do not
+append duplicate rule blocks.
 
 ```yaml
 # ── Capybara ─────────────────────────────────────────

--- a/config/claudius/skills/setup-capybara-lint/skill.yaml
+++ b/config/claudius/skills/setup-capybara-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-commitlint/assets/ci-steps.yml.template
+++ b/config/claudius/skills/setup-commitlint/assets/ci-steps.yml.template
@@ -1,32 +1,58 @@
       - name: Lint commit messages (push)
         if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PUSH_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
-            if [ "${{ github.ref_name }}" = "${{ github.event.repository.default_branch }}" ]; then
-              printf '%s\n' "$(git log -1 --format=%B HEAD)" > /tmp/commit-msg
-              nix develop -c commitlint --edit /tmp/commit-msg
+          tmp_msg="$(mktemp)"
+          trap 'rm -f "$tmp_msg"' EXIT
+
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --prune --unshallow origin
+          fi
+
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            if [ "$REF_NAME" = "$DEFAULT_BRANCH" ]; then
+              git log -1 --format=%B HEAD > "$tmp_msg"
+              nix develop -c commitlint --edit "$tmp_msg"
             else
-              git fetch origin "${{ github.event.repository.default_branch }}" --depth=1
-              base_sha="$(git merge-base HEAD "origin/${{ github.event.repository.default_branch }}" || true)"
-              if [ -n "$base_sha" ]; then
-                nix develop -c commitlint --from "$base_sha" --to HEAD
-              else
-                printf '%s\n' "$(git log -1 --format=%B HEAD)" > /tmp/commit-msg
-                nix develop -c commitlint --edit /tmp/commit-msg
-              fi
+              git fetch --no-tags --prune origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+              base_sha="$(git merge-base HEAD "refs/remotes/origin/${DEFAULT_BRANCH}")"
+              nix develop -c commitlint --from "$base_sha" --to HEAD
             fi
+          elif git cat-file -e "$BEFORE_SHA^{commit}" 2>/dev/null; then
+            nix develop -c commitlint --from "$BEFORE_SHA" --to "$PUSH_SHA"
           else
-            nix develop -c commitlint --from "${{ github.event.before }}" --to "${{ github.sha }}"
+            git fetch --no-tags --prune origin "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+            base_sha="$(git merge-base HEAD "refs/remotes/origin/${DEFAULT_BRANCH}" || true)"
+            if [ -n "$base_sha" ]; then
+              nix develop -c commitlint --from "$base_sha" --to "$PUSH_SHA"
+            else
+              git log -1 --format=%B "$PUSH_SHA" > "$tmp_msg"
+              nix develop -c commitlint --edit "$tmp_msg"
+            fi
           fi
 
       - name: Lint commit messages (pull_request)
         if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          nix develop -c commitlint --from "origin/${{ github.base_ref }}" --to HEAD
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --prune --unshallow origin
+          fi
+          git fetch --no-tags --prune origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          base_sha="$(git merge-base HEAD "refs/remotes/origin/${BASE_REF}")"
+          nix develop -c commitlint --from "$base_sha" --to HEAD
 
       - name: Lint PR title
         if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          printf '%s\n' "${{ github.event.pull_request.title }}" > /tmp/pr-title
-          nix develop -c commitlint --edit /tmp/pr-title
+          tmp_msg="$(mktemp)"
+          trap 'rm -f "$tmp_msg"' EXIT
+          printf '%s\n' "$PR_TITLE" > "$tmp_msg"
+          nix develop -c commitlint --edit "$tmp_msg"

--- a/config/claudius/skills/setup-commitlint/assets/commitlint-pre-push.sh.template
+++ b/config/claudius/skills/setup-commitlint/assets/commitlint-pre-push.sh.template
@@ -1,33 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+tmp_msg=""
+remote_name="${1:-origin}"
+cleanup() {
+  if [ -n "$tmp_msg" ]; then
+    rm -f "$tmp_msg"
+  fi
+}
+trap cleanup EXIT
+
 while read -r _ local_sha _ remote_sha; do
-	if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
-		continue
-	fi
-	if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-		base_ref=""
-		if git show-ref --verify --quiet refs/remotes/origin/HEAD; then
-			base_ref="refs/remotes/origin/HEAD"
-		elif git show-ref --verify --quiet refs/remotes/origin/main; then
-			base_ref="refs/remotes/origin/main"
-		elif git show-ref --verify --quiet refs/remotes/origin/master; then
-			base_ref="refs/remotes/origin/master"
-		fi
-		if [ -n "$base_ref" ]; then
-			base_sha="$(git merge-base "$local_sha" "$base_ref" || true)"
-		else
-			base_sha=""
-		fi
-		if [ -n "$base_sha" ] && [ "$base_sha" != "$local_sha" ]; then
-			commitlint --from "$base_sha" --to "$local_sha"
-		else
-			tmp_msg="$(mktemp)"
-			git log -1 --format=%B "$local_sha" > "$tmp_msg"
-			commitlint --edit "$tmp_msg"
-			rm -f "$tmp_msg"
-		fi
-	else
-		commitlint --from "$remote_sha" --to "$local_sha"
-	fi
+  if [ "$local_sha" = "0000000000000000000000000000000000000000" ]; then
+    continue
+  fi
+  if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+    base_ref=""
+    if git show-ref --verify --quiet "refs/remotes/${remote_name}/HEAD"; then
+      base_ref="refs/remotes/${remote_name}/HEAD"
+    elif git show-ref --verify --quiet "refs/remotes/${remote_name}/main"; then
+      base_ref="refs/remotes/${remote_name}/main"
+    elif git show-ref --verify --quiet "refs/remotes/${remote_name}/master"; then
+      base_ref="refs/remotes/${remote_name}/master"
+    fi
+    if [ -n "$base_ref" ]; then
+      base_sha="$(git merge-base "$local_sha" "$base_ref" || true)"
+    else
+      base_sha=""
+    fi
+    if [ -n "$base_sha" ] && [ "$base_sha" != "$local_sha" ]; then
+      commitlint --from "$base_sha" --to "$local_sha"
+    else
+      tmp_msg="$(mktemp)"
+      git log -1 --format=%B "$local_sha" >"$tmp_msg"
+      commitlint --edit "$tmp_msg"
+      rm -f "$tmp_msg"
+      tmp_msg=""
+    fi
+  else
+    commitlint --from "$remote_sha" --to "$local_sha"
+  fi
 done

--- a/config/claudius/skills/setup-commitlint/instructions.md
+++ b/config/claudius/skills/setup-commitlint/instructions.md
@@ -14,6 +14,32 @@ Read
 [references/scope-taxonomy.md](references/scope-taxonomy.md)
 before deriving the final scope list.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix` (with
@@ -74,15 +100,21 @@ entries.
 
 If the file already exists:
 
-- preserve the current non-scope rules unless they are weaker than the template
-- update only the scope list and any clearly missing baseline rules
+- inspect the current rules and `scope-enum`
+- report the proposed scope/rule delta and ask the user before changing it
+- preserve the current non-scope rules unless the user approves tightening them
+- update only the scope list and any approved, clearly missing baseline rules
 - preserve scope ordering where possible to reduce needless diff churn
 
 ### 3. Create `scripts/commitlint-pre-push.sh`
 
-Create the file using the template in
-[commitlint-pre-push.sh.template](assets/commitlint-pre-push.sh.template). Make
-it executable (`chmod +x`).
+If `scripts/commitlint-pre-push.sh` does not exist, create it using the template
+in [commitlint-pre-push.sh.template](assets/commitlint-pre-push.sh.template).
+Make it executable (`chmod +x`).
+
+If the script already exists, inspect it and ask the user before changing it.
+Merge the missing merge-base behavior without replacing project-specific hook
+logic unless the user approves.
 
 Create the `scripts/` directory if it does not exist.
 
@@ -98,7 +130,8 @@ commitlint-pre-push =
 ```
 
 Do NOT duplicate if they already exist. If they exist in a different style
-(e.g. inline script), replace them with the above.
+(e.g. inline script), inspect the current implementation and ask the user before
+replacing or rewriting it.
 
 ### 5. Add CI workflow steps
 
@@ -111,8 +144,8 @@ of the job if no such step exists). Use the template in
 [ci-steps.yml.template](assets/ci-steps.yml.template).
 
 Do NOT duplicate if commit lint steps already exist. If they exist but use a
-simpler strategy (e.g. `HEAD~1`), replace them with the merge-base approach
-from the template.
+simpler strategy (e.g. `HEAD~1`), explain the proposed merge-base update and ask
+the user before replacing or rewriting the existing steps.
 
 ## Important Notes
 

--- a/config/claudius/skills/setup-commitlint/skill.yaml
+++ b/config/claudius/skills/setup-commitlint/skill.yaml
@@ -10,4 +10,4 @@ targets:
     invocation: manual
     argument-hint: '[optional: comma-separated scopes, e.g. "api,web,ci,deps,docs,nix,scripts,tooling"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-erb-lint/instructions.md
+++ b/config/claudius/skills/setup-erb-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Add ERB template linting, safe HTML parsing, and formatting to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Add gems to `Gemfile`
@@ -16,15 +42,31 @@ gem 'htmlbeautifier', require: false
 
 ### 2. Create `.erb-lint.yml`
 
-Create the file in the Rails root using [erb-lint.yml.template](assets/erb-lint.yml.template).
+If `.erb-lint.yml` does not exist, create it in the Rails root using
+[erb-lint.yml.template](assets/erb-lint.yml.template).
+
+If `.erb-lint.yml` already exists, inspect it and ask the user before changing
+it. Merge missing baseline linters without removing project-specific excludes,
+linters, or parser settings.
 
 ### 3. Create `config/initializers/better_html.rb`
 
-Create the file using [better_html.rb.template](assets/better_html.rb.template). This enforces safe HTML parsing rules that prevent XSS in ERB templates.
+If `config/initializers/better_html.rb` does not exist, create it using
+[better_html.rb.template](assets/better_html.rb.template). This enforces safe
+HTML parsing rules that prevent XSS in ERB templates.
+
+If the initializer already exists, inspect it and ask the user before changing
+it. Preserve project-specific BetterHtml settings and only merge missing safety
+settings when approved.
 
 ### 4. Add to CI
 
-If `.github/workflows/ci.yml` exists, add the following step to the `lint` job:
+If `.github/workflows/ci.yml` exists, inspect it and ask the user before
+changing it. Add the following step to the `lint` job only when there is no
+equivalent ERB lint step already present. Do NOT duplicate an existing
+`erblint`, `erb_lint`, or ERB template lint step. Preserve the existing workflow
+configuration: triggers, jobs, dependency setup, Bundler setup, and job
+structure unless the user approves changing them:
 
 ```yaml
 - name: Lint ERB templates

--- a/config/claudius/skills/setup-erb-lint/skill.yaml
+++ b/config/claudius/skills/setup-erb-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-file-hygiene/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-file-hygiene/assets/hooks.nix.template
@@ -1,8 +1,69 @@
 # ── Formatting & whitespace ──────────────────────────
-editorconfig-checker.enable = true;
-end-of-file-fixer.enable = true;
-trim-trailing-whitespace.enable = true;
-mixed-line-endings.enable = true;
+editorconfig-checker.enable = builtins.pathExists ./.editorconfig;
+final-newline-check = {
+  enable = true;
+  name = "final-newline-check";
+  language = "system";
+  pass_filenames = false;
+  entry =
+    let
+      final-newline-check = pkgs.writeScriptBin "final-newline-check" ''
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        status=0
+        while IFS= read -r -d "" file; do
+          if [ ! -f "$file" ] || [ ! -s "$file" ]; then
+            continue
+          fi
+
+          if ! ${pkgs.gnugrep}/bin/grep -Iq . "$file"; then
+            continue
+          fi
+
+          last_byte="$(${pkgs.coreutils}/bin/tail -c 1 "$file" | ${pkgs.coreutils}/bin/od -An -t x1 | ${pkgs.coreutils}/bin/tr -d '[:space:]')"
+          if [ "$last_byte" != "0a" ]; then
+            echo "final-newline-check: missing final newline: $file" >&2
+            status=1
+          fi
+        done < <(${pkgs.git}/bin/git ls-files -z)
+
+        exit "$status"
+      '';
+    in
+    "${final-newline-check}/bin/final-newline-check";
+};
+trailing-whitespace-check = {
+  enable = true;
+  name = "trailing-whitespace-check";
+  language = "system";
+  pass_filenames = false;
+  entry =
+    let
+      trailing-whitespace-check = pkgs.writeScriptBin "trailing-whitespace-check" ''
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        status=0
+        while IFS= read -r -d "" file; do
+          if [ ! -f "$file" ]; then
+            continue
+          fi
+
+          if ${pkgs.gnugrep}/bin/grep -nI -E '[[:blank:]]$' "$file" >&2; then
+            status=1
+          fi
+        done < <(${pkgs.git}/bin/git ls-files -z)
+
+        exit "$status"
+      '';
+    in
+    "${trailing-whitespace-check}/bin/trailing-whitespace-check";
+};
+mixed-line-endings = {
+  enable = true;
+  args = [ "--fix=no" ];
+};
 
 # ── File checks ──────────────────────────────────────
 check-added-large-files = {
@@ -25,11 +86,19 @@ check-yaml.enable = true;
 # ── Documentation ────────────────────────────────────
 markdownlint = {
   enable = true;
-  settings.configuration = builtins.fromJSON (builtins.readFile ./.markdownlint.json);
+  settings.configuration =
+    if builtins.pathExists ./.markdownlint.json then
+      builtins.fromJSON (builtins.readFile ./.markdownlint.json)
+    else
+      { };
 };
 
 # ── Spelling ─────────────────────────────────────────
 typos = {
   enable = true;
-  settings.configPath = ".typos.toml";
+  settings =
+    if builtins.pathExists ./.typos.toml then
+      { configPath = ".typos.toml"; }
+    else
+      { config = { }; };
 };

--- a/config/claudius/skills/setup-file-hygiene/instructions.md
+++ b/config/claudius/skills/setup-file-hygiene/instructions.md
@@ -2,6 +2,32 @@
 
 Add general file quality and hygiene hooks to the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix`. If not, tell the user to run `/setup-git-hooks` first.
@@ -15,10 +41,10 @@ Add the hooks from [hooks.nix.template](assets/hooks.nix.template) into the `hoo
 Hooks added:
 
 **Formatting & whitespace:**
-- **editorconfig-checker** — Validates `.editorconfig` rules
-- **end-of-file-fixer** — Ensures files end with a newline
-- **trim-trailing-whitespace** — Removes trailing whitespace
-- **mixed-line-endings** — Detects mixed line endings (LF/CRLF)
+- **editorconfig-checker** — Validates `.editorconfig` rules when `.editorconfig` exists; disabled otherwise
+- **final-newline-check** — Checks tracked non-empty text files end with a newline without rewriting them
+- **trailing-whitespace-check** — Checks tracked text files for trailing whitespace without rewriting them
+- **mixed-line-endings** — Detects mixed line endings (LF/CRLF) without rewriting files
 
 **File checks:**
 - **check-added-large-files** — Blocks files over 200KB
@@ -36,21 +62,27 @@ Hooks added:
 - **check-yaml** — Validates YAML syntax
 
 **Documentation:**
-- **markdownlint** — Lints Markdown files using `.markdownlint.json` config
+- **markdownlint** — Lints Markdown files using `.markdownlint.json` config when present, or markdownlint defaults otherwise
 
 **Spelling:**
-- **typos** — Detects typos using `.typos.toml` config
+- **typos** — Detects typos using `.typos.toml` config when present, or typos defaults otherwise
 
 ### 2. Remind the user about config files
 
-After completing the setup, remind the user that these hooks expect the following config files. Do NOT create them — just list any that are missing:
+After completing the setup, remind the user about the following config files. Do
+NOT create them automatically — just list any that are missing:
 
-- `.editorconfig` — EditorConfig rules
-- `.markdownlint.json` — markdownlint configuration
-- `.typos.toml` — typos configuration
+- `.editorconfig` — EditorConfig rules (optional; editorconfig-checker is disabled when missing)
+- `.markdownlint.json` — markdownlint configuration (optional; defaults are used when missing)
+- `.typos.toml` — typos configuration (optional; defaults are used when missing)
 
 ## Important Notes
 
 - Do NOT remove or modify any existing hooks.
+- Keep file hygiene hooks check-only by default. Do NOT enable mutating hooks
+  such as `end-of-file-fixer` or `trim-trailing-whitespace` unless the user
+  explicitly accepts auto-fix behavior.
+- Keep `mixed-line-endings` configured with `--fix=no`. Its upstream default
+  rewrites files, which violates the check-only policy.
 - The `check-added-large-files` hook uses `--maxkb=200`. If the project has large generated files that should be excluded, the user should add `excludes` entries.
-- The `typos` hook uses `.typos.toml` via `configPath`. If the project has directories that should be excluded (generated code, vendored deps), the user should add `exclude` entries to the typos settings.
+- The `typos` hook uses `.typos.toml` via `configPath` only when the file exists. If the project has directories that should be excluded (generated code, vendored deps), the user should add `exclude` entries to the typos settings or create `.typos.toml`.

--- a/config/claudius/skills/setup-file-hygiene/skill.yaml
+++ b/config/claudius/skills/setup-file-hygiene/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-git-hooks/instructions.md
+++ b/config/claudius/skills/setup-git-hooks/instructions.md
@@ -3,6 +3,32 @@
 Integrate [cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix) into
 the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 1. Read the existing `flake.nix` in the project root.
@@ -15,8 +41,10 @@ the project's `flake.nix`.
    ```
 
    If the project uses the old name `pre-commit-hooks` (i.e.
-   `github:cachix/pre-commit-hooks.nix`), rename it to `git-hooks` and update
-   all references throughout the file.
+   `github:cachix/pre-commit-hooks.nix`), inspect all references first, report
+   the proposed rename from `pre-commit-hooks` to `git-hooks`, and ask the user
+   before changing it. When approved, update all references consistently in the
+   same change.
 
 3. **Add `git-hooks` to the outputs function parameters** (if not already
    present).

--- a/config/claudius/skills/setup-git-hooks/skill.yaml
+++ b/config/claudius/skills/setup-git-hooks/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: (no arguments required)
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-github-guardrails/instructions.md
+++ b/config/claudius/skills/setup-github-guardrails/instructions.md
@@ -8,6 +8,32 @@ Align GitHub-hosted workflow policy with a shared quality profile.
 - `tofu-infra`
 - `polyglot-oss`
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Profile References
 
 Read the matching quality-profile reference before editing:

--- a/config/claudius/skills/setup-github-guardrails/skill.yaml
+++ b/config/claudius/skills/setup-github-guardrails/skill.yaml
@@ -10,4 +10,4 @@ targets:
     invocation: manual
     argument-hint: '[rails-monorepo|tofu-infra|polyglot-oss]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-google-workspace-iac/instructions.md
+++ b/config/claudius/skills/setup-google-workspace-iac/instructions.md
@@ -1,0 +1,237 @@
+# Setup Google Workspace IaC
+
+Define a safe Google Workspace and Cloud Identity infrastructure-as-code model for
+OpenTofu/Terraform repositories.
+
+Use this skill when the user wants to manage Google Workspace domains, Cloud
+Identity, groups, organizational units, admin roles, SAML/OIDC applications, or
+workspace security settings as code. For Google Cloud platform resources, use the
+GCP section of `/setup-multicloud-iac-structure` instead.
+
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask
+the user to confirm the proposed change. This applies even when the change is
+additive, such as merging config keys, appending CI steps, adding package
+scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the
+user explicitly requested applying all changes without confirmation. Preserve
+project-specific settings and avoid replacing entire files unless the user
+approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
+## Core Principles
+
+- Treat the Google Workspace customer, primary domain, and Cloud Identity tenant
+  as the top-level ownership boundary.
+- Separate identity governance from Google Cloud project infrastructure.
+- Keep users, groups, applications, and security policy in separate state
+  boundaries unless the repository documents a deliberate reason to combine them.
+- Prefer declarative catalogs for intended ownership and membership, but do not
+  silently switch existing directories to authoritative management.
+- Never manage passwords, recovery channels, backup codes, or one-time secrets in
+  Terraform state.
+- Keep super-admin and break-glass access small, explicit, and manually
+  reviewable.
+- Make OAuth scopes and domain-wide delegation grants minimal and auditable.
+
+## Target Layout
+
+Use this shape for new repositories or as a migration target:
+
+```text
+stacks/
+  google-workspace/
+    customers/<customer-id-or-domain>/
+      customer.hcl
+      global/
+        bootstrap/
+        domains/
+        security/
+      identity/
+        organizational-units/
+        groups/
+        group-settings/
+        admin-roles/
+      applications/
+        saml/<application>/
+        oidc/<application>/
+      devices/
+        chrome/
+        mobile/
+
+modules/
+  google-workspace/
+    group/
+    saml-app/
+    admin-role/
+
+catalog/
+  identity/
+    groups.yaml
+    applications.yaml
+
+docs/
+  identity/
+
+results/
+```
+
+Use provider-native identifiers in state and metadata:
+
+- `customer_id`
+- `primary_domain`
+- `domain`
+- `org_unit_path`
+- `group_email`
+- `application_id`
+
+## State Boundary Guidance
+
+Use separate root modules for:
+
+- bootstrap provider access, delegated service accounts, and audit-only data
+  sources
+- domains and customer-wide settings
+- organizational units
+- groups and group settings
+- group memberships when the membership set is large or imported
+- admin roles and role assignments
+- SAML or OIDC applications
+- Chrome, mobile, or endpoint device policy
+
+Do not combine all Google Workspace resources into one state for convenience.
+Directory-wide changes can be high blast-radius, and plans become hard to
+review.
+
+## Existing Directory Safety
+
+Before adopting an existing Google Workspace object:
+
+1. Export or inspect the current object and its owners.
+2. Decide whether the Terraform resource will be authoritative or additive.
+3. Show the user the proposed import and management mode.
+4. Ask the user before changing membership, admin role bindings, app assignment,
+   or security policy.
+
+For groups, explicitly classify each group:
+
+- `authoritative`: Terraform owns the full membership set.
+- `additive`: Terraform manages only selected members or settings.
+- `catalog-only`: Terraform records intent but does not apply membership.
+
+Do not convert a group to authoritative management unless the user approves the
+complete membership source of truth.
+
+## Identity Data and Artifact Policy
+
+Treat Google Workspace exports, group membership lists, admin role assignments,
+application assignments, and plan output as identity and access data even when
+they are not credentials.
+
+- Do not commit raw admin exports, user lists, group membership dumps, role
+  assignment exports, application assignment exports, or unsanitized plan output
+  unless the user explicitly approves committing that exact artifact.
+- Commit `catalog/identity/` files only after the user confirms they are the
+  intended source of truth and they have been reviewed for personal data and
+  authorization exposure.
+- Prefer storing raw discovery exports outside the repository, or in an
+  encrypted/approved evidence location defined by the repository. If `results/`
+  is used, sanitize or mask user emails, external identities, recovery metadata,
+  and admin-role bindings before committing.
+- Include `data_sensitivity` and `commit_allowed` in migration tables for any
+  artifact derived from a live directory.
+
+## Credential and Secret Policy
+
+Keep credentials outside the repository:
+
+- Use environment variables, CI secrets, or a secret manager for provider
+  credentials.
+- Do not commit service-account keys, OAuth client secrets, delegated admin user
+  emails, refresh tokens, or `.tfvars` files containing sensitive values.
+- Prefer short-lived or centrally rotated credentials where the provider and CI
+  platform support them.
+- Keep domain-wide delegation scopes minimal and document why each scope is
+  required.
+
+Provider configuration should read credential material from the environment or
+from sensitive variables supplied by CI. Do not hard-code credentials in
+`provider.tf`.
+
+## AWS and External IdP Integration
+
+When Google Workspace or Cloud Identity federates users into AWS:
+
+- Keep the Google Workspace SAML/OIDC application in a Google Workspace app
+  state boundary.
+- Keep AWS IAM Identity Center, IAM roles, account assignments, and permission
+  sets in AWS infrastructure state.
+- Connect the two through explicit catalog metadata such as app name, entity ID,
+  ACS URL, group mapping, and owner.
+- Do not let a Google Workspace state mutate AWS account assignments directly.
+
+This keeps identity application configuration separate from cloud account
+authorization.
+
+## Migration Workflow
+
+1. Inventory existing domains, OUs, groups, admin roles, applications, and
+   high-risk security settings.
+2. Produce a migration table with `object`, `current_owner`, `target_state`,
+   `management_mode`, `import_command`, `data_sensitivity`, `commit_allowed`,
+   and `risk`.
+3. Import one object class at a time.
+4. Run plans with read-only review first and confirm destructive diffs before
+   apply.
+5. Move membership-heavy resources last, after the source of truth is clear.
+
+Store only sanitized reproducible command output in `results/`. Store raw
+identity exports outside the repository unless the user explicitly approves a
+repository location. Store agent-only working notes in `.agents/products/` only
+when the repository policy allows it.
+
+## Validation
+
+For each root module:
+
+1. Run `tofu fmt -check -diff`.
+2. Run `tofu init -backend=false -lockfile=readonly` when provider plugins are
+   locked.
+3. Run `tofu validate`.
+4. Run a plan only with approved credentials and the intended state backend.
+
+Do not run an apply until the user has reviewed the import and management-mode
+table for existing objects.
+
+## Completion Summary
+
+When finished, report:
+
+- state boundaries created or changed
+- existing objects imported or left unmanaged
+- authoritative vs additive group-management choices
+- identity/access artifacts committed, sanitized, or kept outside the repository
+- domain-wide delegation scopes and credential assumptions
+- validation commands run
+- remaining high-risk manual approvals

--- a/config/claudius/skills/setup-google-workspace-iac/skill.yaml
+++ b/config/claudius/skills/setup-google-workspace-iac/skill.yaml
@@ -1,0 +1,12 @@
+version: 1
+name: setup-google-workspace-iac
+description: >-
+  Define Google Workspace and Cloud Identity IaC structure, state boundaries,
+  credential policy, group-management modes, and AWS federation separation for
+  OpenTofu/Terraform repositories.
+targets:
+  claude-code:
+    invocation: manual
+    argument-hint: "[new|migrate] [optional domain/customer]"
+  codex:
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-haskell-lint/assets/haskell-strict-check.sh.template
+++ b/config/claudius/skills/setup-haskell-lint/assets/haskell-strict-check.sh.template
@@ -27,14 +27,14 @@ detect_build_tool() {
 tool="$(detect_build_tool)"
 
 case "$tool" in
-  cabal)
-    cabal build all --ghc-options="$strict_ghc_options"
-    ;;
-  stack)
-    stack build --ghc-options "$strict_ghc_options"
-    ;;
-  *)
-    echo "Unsupported Haskell build tool: $tool" >&2
-    exit 1
-    ;;
+cabal)
+  cabal build all --ghc-options="$strict_ghc_options"
+  ;;
+stack)
+  stack build --ghc-options "$strict_ghc_options"
+  ;;
+*)
+  echo "Unsupported Haskell build tool: $tool" >&2
+  exit 1
+  ;;
 esac

--- a/config/claudius/skills/setup-haskell-lint/instructions.md
+++ b/config/claudius/skills/setup-haskell-lint/instructions.md
@@ -7,6 +7,32 @@ that treats warnings as errors.
 **The argument `$ARGUMENTS` is optional** and may provide `build_tool=cabal`,
 `build_tool=stack`, or `build_tool=auto` (default).
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have Haskell package metadata such as a `.cabal` file,
@@ -85,9 +111,13 @@ Do NOT overwrite existing ignores or project-specific restrictions.
 
 ### 3. Create `scripts/haskell-strict-check.sh`
 
-Create `scripts/haskell-strict-check.sh` from
+If `scripts/haskell-strict-check.sh` does not exist, create it from
 [haskell-strict-check.sh.template](assets/haskell-strict-check.sh.template) and
 make it executable.
+
+If the script already exists, inspect it and ask the user before changing it.
+Merge missing strict-check behavior without replacing project-specific build-tool
+selection or flags unless approved.
 
 The script:
 

--- a/config/claudius/skills/setup-haskell-lint/skill.yaml
+++ b/config/claudius/skills/setup-haskell-lint/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: '[build_tool=auto|cabal|stack]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-i18n-lint/assets/i18n-tasks.yml.template
+++ b/config/claudius/skills/setup-i18n-lint/assets/i18n-tasks.yml.template
@@ -1,5 +1,5 @@
-base_locale: ja
-locales: [ja, en]
+base_locale: __BASE_LOCALE__
+locales: __LOCALES__
 
 data:
   adapter: file

--- a/config/claudius/skills/setup-i18n-lint/instructions.md
+++ b/config/claudius/skills/setup-i18n-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Add i18n-tasks (translation management) and rubocop-i18n (hardcoded string detection) to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - RuboCop must be installed. If not, tell the user to run `/setup-rubocop` first.
@@ -19,9 +45,12 @@ gem 'rubocop-i18n', require: false
 
 ### 2. Add `rubocop-i18n` plugin to `.rubocop.yml`
 
-Add `rubocop-i18n` to the `plugins` list in `.rubocop.yml`.
+Add `rubocop-i18n` to the `plugins` list in `.rubocop.yml` only if it is not
+already present.
 
-Then append the following rules:
+Then ensure the following rules are present. If equivalent rules already exist,
+preserve the current values and ask the user before changing them. Do not append
+duplicate rule blocks.
 
 ```yaml
 # ── i18n ─────────────────────────────────────────────
@@ -36,11 +65,28 @@ I18n/GetText:
 
 ### 3. Create `config/i18n-tasks.yml`
 
-Create the file using [i18n-tasks.yml.template](assets/i18n-tasks.yml.template).
+If `config/i18n-tasks.yml` does not exist, create it using
+[i18n-tasks.yml.template](assets/i18n-tasks.yml.template).
+
+If `config/i18n-tasks.yml` already exists, inspect it and ask the user before
+changing it. Merge missing baseline settings without replacing locale paths,
+ignore patterns, scanner settings, or project-specific data configuration.
+
+Infer the locale values before writing the file:
+
+- `__BASE_LOCALE__` — the Rails `I18n.default_locale`, or the only locale found under `config/locales`, or ask the user if unclear
+- `__LOCALES__` — YAML inline list of supported locales found under `config/locales` or `I18n.available_locales`, for example `[en, ja]`
+
+Do not leave locale placeholders in `config/i18n-tasks.yml`. Do not assume `ja` unless the repository already uses Japanese as its default locale.
 
 ### 4. Add to CI
 
-If `.github/workflows/ci.yml` exists, add the following step to the `lint` job:
+If `.github/workflows/ci.yml` exists, inspect it and ask the user before
+changing it. Add the following step to the `lint` job only when there is no
+equivalent i18n-tasks step already present. Do NOT duplicate an existing
+`i18n-tasks missing`, `i18n-tasks unused`, or translation-health step. Preserve
+the existing workflow configuration: triggers, jobs, dependency setup, Bundler
+setup, and job structure unless the user approves changing them:
 
 ```yaml
 - name: Check for missing and unused translations

--- a/config/claudius/skills/setup-i18n-lint/skill.yaml
+++ b/config/claudius/skills/setup-i18n-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-iac-security/instructions.md
+++ b/config/claudius/skills/setup-iac-security/instructions.md
@@ -2,6 +2,32 @@
 
 Add IaC security scanning hooks to the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix`. If not, tell the user to run `/setup-git-hooks` first.

--- a/config/claudius/skills/setup-iac-security/skill.yaml
+++ b/config/claudius/skills/setup-iac-security/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-just-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-just-lint/assets/hooks.nix.template
@@ -1,2 +1,2 @@
 just-fmt-check = mkHook "just-fmt-check" "just --fmt --check --unstable";
-just-evaluate = mkHook "just-evaluate" "just --evaluate --justfile";
+just-evaluate = mkHook "just-evaluate" "just --evaluate";

--- a/config/claudius/skills/setup-just-lint/instructions.md
+++ b/config/claudius/skills/setup-just-lint/instructions.md
@@ -7,6 +7,32 @@ As of 2026-02, the justfile ecosystem provides **no third-party linters**. This 
 - `just --fmt --check --unstable` — formatting conformance (check-only, no auto-fix)
 - `just --evaluate` — variable resolution and recipe parse validation
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - `just` (>= 1.0.0) must be available in the environment.
@@ -58,7 +84,11 @@ Hooks added:
 
 #### B-2. Remove abandoned third-party hooks
 
-If `.pre-commit-config.yaml` contains a reference to `instrumentl/pre-commit-just`, remove it. This repository has been abandoned since January 2024 and is no longer maintained. Replace with the local hooks from B-1.
+If `.pre-commit-config.yaml` contains a reference to
+`instrumentl/pre-commit-just`, report that it has been abandoned since January
+2024 and is no longer maintained. Propose removing that hook and replacing it
+with the local hooks from B-1, but ask the user before changing the existing
+`.pre-commit-config.yaml`.
 
 ---
 
@@ -106,7 +136,7 @@ As of `just` v1.46.0 (2026-01):
 
 ## Important Notes
 
-- Do NOT remove or modify any existing hooks.
+- Do NOT remove or modify any existing hooks without explicit user approval.
 - Do NOT use `instrumentl/pre-commit-just` — it is abandoned and unmaintained.
 - Do NOT enable auto-fix (`just --fmt --unstable` without `--check`) in pre-commit hooks or CI. The known bugs make auto-formatting destructive in edge cases. Provide `meta-format` as an explicit, user-initiated recipe only.
 - The `--unstable` flag is required for all `--fmt` operations. This is a `just` upstream constraint, not a policy choice.

--- a/config/claudius/skills/setup-just-lint/skill.yaml
+++ b/config/claudius/skills/setup-just-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-just/assets/justfile.template
+++ b/config/claudius/skills/setup-just/assets/justfile.template
@@ -6,8 +6,8 @@
 # ---------------------------------------------------------------------------
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
-set positional-arguments := true
-set export := true
+set positional-arguments
+set export
 
 # ---------------------------------------------------------------------------
 # Project metadata
@@ -25,7 +25,7 @@ default:
 
 # Display project help
 help:
-    @echo "{{project_name}}"
+    @echo "{{ project_name }}"
     @echo ""
     @just --list --unsorted
 

--- a/config/claudius/skills/setup-just/instructions.md
+++ b/config/claudius/skills/setup-just/instructions.md
@@ -4,6 +4,32 @@ Create a `justfile` with mandatory baseline recipes and strict shell safety sett
 
 **The argument `$ARGUMENTS` is the project name** used for metadata in the justfile (e.g. `my-project`). If no argument is given, infer from the current directory name.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - `just` must be available in the environment. If the project uses Nix Flakes, `just` MUST be declared in `flake.nix` `devShells.default.buildInputs` (or equivalent). If `just` is not available, tell the user to add `pkgs.just` to their dev shell or install `just` via their system package manager. Do NOT proceed without confirming availability.
@@ -18,12 +44,18 @@ If no justfile exists, create `justfile` (lowercase, no extension) from [justfil
 
 ### 2. Verify mandatory settings
 
-The following settings MUST be present at the top of the justfile, before any recipe. If any are missing, add them. If they exist with different values, **replace** them with the values below — there is no valid reason to deviate.
+The following settings SHOULD be present at the top of the justfile, before any
+recipe. If the justfile was created by this skill in the current run, add them.
+
+If an existing justfile is missing any setting or uses different values, inspect
+the current content, explain the behavior change, and ask the user before adding
+or replacing mandatory settings. Preserve project-specific shell behavior unless
+the user approves the baseline change.
 
 ```just
 set shell := ["bash", "-euo", "pipefail", "-c"]
-set positional-arguments := true
-set export := true
+set positional-arguments
+set export
 ```
 
 These enforce:
@@ -40,7 +72,12 @@ Do NOT add `set windows-shell` unless the project explicitly requires Windows su
 
 ### 3. Verify mandatory recipes
 
-The following six recipes MUST be present. If any are missing, add them. Do NOT modify the implementation of existing recipes that already match the required signature — only add recipes that are entirely absent.
+The following six recipes SHOULD be present. If the justfile was created by this
+skill in the current run, add them.
+
+If an existing justfile is missing any recipe, inspect nearby setup recipes,
+propose wrapper or stub additions, and ask the user before editing. Do NOT modify
+the implementation of existing recipes that already match the required signature.
 
 | Recipe | Signature | Purpose |
 |---|---|---|
@@ -51,7 +88,10 @@ The following six recipes MUST be present. If any are missing, add them. Do NOT 
 | `install-tools` | `install-tools:` | Install development tools |
 | `install-hooks` | `install-hooks:` | Install git hooks |
 
-If a recipe exists under a different name that serves the same purpose (e.g. `setup` instead of `install`), do NOT rename it. Add the mandatory recipe name as a wrapper that delegates to the existing one using `just <existing-recipe>`.
+If a recipe exists under a different name that serves the same purpose (e.g.
+`setup` instead of `install`), do NOT rename it. For existing justfiles, ask
+before adding the mandatory recipe name as a wrapper that delegates to the
+existing one using `just <existing-recipe>`.
 
 ### 4. Verify section marker
 
@@ -63,7 +103,10 @@ Mandatory recipes MUST be grouped under this comment block:
 # =========================================================================
 ```
 
-If this marker does not exist, add it immediately above the first mandatory recipe. Do NOT move or reorder any existing recipes that are outside the mandatory block.
+If this marker does not exist in a justfile created by this skill in the current
+run, add it immediately above the first mandatory recipe. For existing justfiles,
+ask the user before adding the marker. Do NOT move or reorder any existing
+recipes that are outside the mandatory block.
 
 ### 5. Nix Flake coordination (conditional)
 
@@ -86,7 +129,10 @@ Do NOT add this comment if `flake.nix` does not exist.
 
 ### 6. Validate
 
-Run `just --evaluate` to confirm the justfile parses without errors. If it fails, fix syntax errors before finishing. Do NOT leave a broken justfile.
+Run `just --evaluate` to confirm the justfile parses without errors. Also run
+`just --fmt --check --unstable` for a justfile created from this skill's
+template. If either command fails, fix syntax or canonical formatting before
+finishing. Do NOT leave a broken or non-canonical generated justfile.
 
 ## Important Notes
 

--- a/config/claudius/skills/setup-just/skill.yaml
+++ b/config/claudius/skills/setup-just/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: '[project name, e.g. "my-project"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-lean-lint/assets/lean-lint-check.sh.template
+++ b/config/claudius/skills/setup-lean-lint/assets/lean-lint-check.sh.template
@@ -1,22 +1,29 @@
 #!/usr/bin/env bash
-set -eu
-
-scope="${LEAN_LINT_SCOPE:-clippy}"
+set -euo pipefail
 
 lake build
 
-case "$scope" in
-  default)
-    lake lint
-    ;;
-  clippy)
-    lake lint --clippy
-    ;;
-  all)
-    lake lint --lint-all
-    ;;
-  *)
-    echo "Unsupported LEAN_LINT_SCOPE: $scope" >&2
-    exit 1
-    ;;
-esac
+lint_output=""
+set +e
+lint_output="$(lake lint 2>&1)"
+lint_status=$?
+set -e
+
+if [ "${lint_status}" -eq 0 ]; then
+  printf '%s\n' "$lint_output"
+  exit 0
+fi
+
+if printf '%s\n' "$lint_output" | grep -qi "no lint driver configured"; then
+  if [ "${LEAN_LINT_REQUIRE_DRIVER:-0}" = "1" ]; then
+    printf '%s\n' "$lint_output" >&2
+    exit "$lint_status"
+  fi
+
+  echo "lean-lint-check: no Lake lint driver configured; build passed, lint skipped." >&2
+  echo "Set LEAN_LINT_REQUIRE_DRIVER=1 to fail when lint is unavailable." >&2
+  exit 0
+fi
+
+printf '%s\n' "$lint_output" >&2
+exit "$lint_status"

--- a/config/claudius/skills/setup-lean-lint/instructions.md
+++ b/config/claudius/skills/setup-lean-lint/instructions.md
@@ -1,8 +1,34 @@
 # Setup Lean Lint
 
 Add Lean quality checks for a Lake project. This skill standardizes on
-`lake build` plus `lake lint`, using the built-in Clippy-style linters by
-default. Keep the formatting surface project-specific and check-only.
+`lake build` plus `lake lint` when the project exposes a Lake lint driver. Keep
+the formatting surface project-specific and check-only.
+
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
 
 ## Prerequisites
 
@@ -58,16 +84,20 @@ Hook added:
 
 ### 2. Create `scripts/lean-lint-check.sh`
 
-Create `scripts/lean-lint-check.sh` from
+If `scripts/lean-lint-check.sh` does not exist, create it from
 [lean-lint-check.sh.template](assets/lean-lint-check.sh.template) and make it
 executable.
+
+If the script already exists, inspect it and ask the user before changing it.
+Merge missing Lean quality checks without replacing project-specific Lake or
+lint-driver logic unless approved.
 
 The script:
 
 - runs `lake build`
-- runs `lake lint --clippy` by default
-- supports `LEAN_LINT_SCOPE=default|clippy|all` to adjust the built-in linter
-  scope
+- runs `lake lint` when a project lint driver is configured
+- skips lint with a clear message when no Lake lint driver is configured
+- supports `LEAN_LINT_REQUIRE_DRIVER=1` to fail if lint is unavailable
 
 ### 3. Inspect the project's strictness surface
 
@@ -96,5 +126,7 @@ built-in linter scope globally just to get the hook green.
 - Do NOT invent an auto-format hook that rewrites files during commit.
 - Keep formatting editor- or project-command driven unless the repository
   already has a checked formatter surface.
-- Use `LEAN_LINT_SCOPE=all` only when the project is already ready for the
-  broader lint set; `clippy` is the strict default for general Lean projects.
+- Lake does not provide a universal `--clippy` or `--lint-all` flag. Preserve
+  any project-specific lint driver and run `lake lint` through that driver.
+- Set `LEAN_LINT_REQUIRE_DRIVER=1` only when the repository requires a configured
+  lint driver before commits or CI may pass.

--- a/config/claudius/skills/setup-lean-lint/skill.yaml
+++ b/config/claudius/skills/setup-lean-lint/skill.yaml
@@ -1,10 +1,10 @@
 version: 1
 name: setup-lean-lint
 description: >-
-  Set up lake build and strict lake lint checks for a Lean 4 Lake project with
+  Set up lake build and Lake lint-driver checks for a Lean 4 Lake project with
   check-only hooks. Use when adding Lean quality gates.
 targets:
   claude-code:
     invocation: manual
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-local-quality-loop/instructions.md
+++ b/config/claudius/skills/setup-local-quality-loop/instructions.md
@@ -9,6 +9,32 @@ project-specific policy surface.
 - `tofu-infra`
 - `polyglot-oss`
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Profile References
 
 Read the matching quality-profile reference before editing:

--- a/config/claudius/skills/setup-local-quality-loop/skill.yaml
+++ b/config/claudius/skills/setup-local-quality-loop/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: '[rails-monorepo|tofu-infra|polyglot-oss]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-multicloud-iac-structure/instructions.md
+++ b/config/claudius/skills/setup-multicloud-iac-structure/instructions.md
@@ -7,6 +7,38 @@ Use this skill when the user wants a durable directory standard, state-boundary 
 path for AWS, Azure, and GCP infrastructure. This skill focuses on repository architecture, not
 linting or CI. For quality gates, use `/setup-tofu-project` after the structure is in place.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask
+the user to confirm the proposed change. This applies even when the change is
+additive, such as merging config keys, appending CI steps, adding package
+scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the
+user explicitly requested applying all changes without confirmation. Preserve
+project-specific settings and avoid replacing entire files unless the user
+approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Core Principles
 
 - `stacks/` contains execution units and state boundaries.
@@ -209,13 +241,17 @@ committed by the user. Do not create hidden coupling.
 
 For a new repository:
 
-1. Create `stacks/aws`, `stacks/azure`, `stacks/gcp`, `modules`, `catalog`, `docs`, and `results`.
-2. Add provider-specific `modules/` directories only when provider-specific modules exist.
-3. Add `_naming` and provider adapter modules if the repository needs shared naming.
-4. Add at least one region catalog file per governed region.
-5. Add a short `docs/infrastructure-as-code/directory-structure.md` describing the state boundary
+1. Determine the target clouds from `$ARGUMENTS` or the user's request. If the target clouds are
+   unclear, ask before creating cloud-specific directories. Do not create `stacks/aws`,
+   `stacks/azure`, or `stacks/gcp` for clouds outside the confirmed scope.
+2. Create only the selected `stacks/<cloud>` directories, plus `modules`, `catalog`, `docs`, and
+   `results`.
+3. Add provider-specific `modules/` directories only when provider-specific modules exist.
+4. Add `_naming` and provider adapter modules only for selected clouds that need shared naming.
+5. Add region catalog files only for governed regions in the selected clouds.
+6. Add a short `docs/infrastructure-as-code/directory-structure.md` describing the state boundary
    and global/regional rules.
-6. Apply `/setup-tofu-project` or component quality skills after the structure exists.
+7. Apply `/setup-tofu-project` or component quality skills after the structure exists.
 
 ## Safety Rules
 

--- a/config/claudius/skills/setup-multicloud-iac-structure/skill.yaml
+++ b/config/claudius/skills/setup-multicloud-iac-structure/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: "[new|migrate] [optional target clouds/regions]"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-nix-ci-lint/instructions.md
+++ b/config/claudius/skills/setup-nix-ci-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Generate `.github/workflows/lint.yml` by reading the project's `flake.nix` hook configuration and building a GitHub Actions workflow using Determinate Systems actions.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Read the project's `flake.nix`
@@ -11,9 +37,20 @@ Read `flake.nix` in the project root and extract:
 - Whether commitlint hooks exist (commit-msg / pre-push stages)
 - Any hooks that may need initialization or special CI handling
 
-### 2. Create `.github/workflows/lint.yml`
+### 2. Create or update `.github/workflows/lint.yml`
 
-Create the workflow using [lint.yml.template](assets/lint.yml.template) as the base structure. The base provides:
+If `.github/workflows/lint.yml` does not exist, create it using
+[lint.yml.template](assets/lint.yml.template) as the base structure.
+
+If `.github/workflows/lint.yml` already exists, inspect it and ask the user
+before changing it. Merge missing Nix setup, cache, dependency installation,
+pre-commit, and commitlint steps into the existing workflow. Do not replace the
+workflow wholesale unless the user explicitly approves that replacement.
+Preserve project-specific triggers, path filters, job names, matrices,
+permissions, concurrency, and environment variables unless they conflict with
+the requested lint policy.
+
+The base provides:
 - Trigger on `pull_request` and `push` to all branches
 - Checkout with `fetch-depth: 0` (needed for commitlint range checks)
 - minimal `contents: read` permissions by default
@@ -60,13 +97,22 @@ If no dependency installation is needed (common for pure IaC projects), skip thi
 
 ### 6. Add commitlint CI steps
 
-If commitlint hooks are present in the flake, append the commit message linting steps. These steps are defined by the `/setup-commitlint` skill's CI template — read the `setup-commitlint` skill asset `assets/ci-steps.yml.template` and append its contents after the "Run pre-commit hooks" step.
+If commitlint hooks are present in the flake, add the commit message linting
+steps. These steps are defined by the `/setup-commitlint` skill's CI template —
+read the `setup-commitlint` skill asset `assets/ci-steps.yml.template` and add
+its contents after the "Run pre-commit hooks" step.
+
+Before changing the workflow, check whether equivalent commitlint or PR-title
+lint steps already exist. Do NOT duplicate them. If existing steps use a simpler
+range strategy such as `HEAD~1`, explain the proposed merge-base update and ask
+the user before replacing or rewriting those steps.
 
 If commitlint hooks are not present, skip this step.
 
 ## Important Notes
 
-- If `.github/workflows/lint.yml` already exists, ask the user before overwriting.
+- If `.github/workflows/lint.yml` already exists, merge/update it in place; ask
+  the user before any broad replacement or policy-changing rewrite.
 - Do NOT hardcode project-specific details. Derive everything from the flake.nix configuration.
 - The `fetch-depth: 0` on checkout is required for commitlint `--from`/`--to` range checks to work. Always include it even if commitlint is not yet configured, to avoid needing to change it later.
 - The Determinate Systems actions handle Nix installation and caching. Do NOT use `cachix/install-nix-action` or other alternatives.

--- a/config/claudius/skills/setup-nix-ci-lint/skill.yaml
+++ b/config/claudius/skills/setup-nix-ci-lint/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-nix-flake/instructions.md
+++ b/config/claudius/skills/setup-nix-flake/instructions.md
@@ -4,6 +4,32 @@ Create a minimal `flake.nix` with an empty devShell and a `.envrc` for direnv in
 
 **The argument `$ARGUMENTS` is a short project description** used in the flake's `description` field (e.g. `Development environment for my-api`). If no argument is given, infer from the current directory name and format as `Development environment for <dir-name>`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - `nix` must be installed with flakes enabled (`experimental-features = nix-command flakes`). If not available, tell the user to install Nix first. Do NOT proceed without it.
@@ -37,7 +63,9 @@ These belong in downstream skills or project-specific customization.
 
 ### 3. Create `.envrc`
 
-If `.envrc` already exists in the project root, verify it contains `use flake`. If it does, skip this step. If it does not, append `use flake` to the file.
+If `.envrc` already exists in the project root, verify it contains `use flake`.
+If it does, skip this step. If it does not, inspect the current content, explain
+the proposed `use flake` addition, and ask the user before appending it.
 
 If `.envrc` does not exist, create it from [envrc.template](assets/envrc.template).
 
@@ -45,7 +73,9 @@ Do NOT run `direnv allow` — the user must do this explicitly as a security dec
 
 ### 4. Ensure `.envrc.local` is git-ignored
 
-If `.gitignore` exists, check whether it contains `.envrc.local`. If not, append it.
+If `.gitignore` exists, check whether it contains `.envrc.local`. If not,
+inspect the current content, explain the proposed ignore entry, and ask the user
+before appending it.
 
 If `.gitignore` does not exist, create it with `.envrc.local` as the sole entry.
 

--- a/config/claudius/skills/setup-nix-flake/skill.yaml
+++ b/config/claudius/skills/setup-nix-flake/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: '[project description, e.g. "Development environment for my-api"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-nix-lint/instructions.md
+++ b/config/claudius/skills/setup-nix-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Add Nix-specific lint hooks and `nix fmt` formatter output to the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix` (with `mkHook`/`mkHookWithStages` helpers available). If not, tell the user to run `/setup-git-hooks` first.

--- a/config/claudius/skills/setup-nix-lint/skill.yaml
+++ b/config/claudius/skills/setup-nix-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-pandacss/instructions.md
+++ b/config/claudius/skills/setup-pandacss/instructions.md
@@ -10,6 +10,32 @@ This skill is based on practices proven useful in a React Router 7 admin-console
 - Use explicit CSS cascade layers and React Router-compatible stylesheet loading.
 - Add check-only enforcement for inline styles, raw colors, and missing Panda config basics.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have a `package.json`.
@@ -62,7 +88,13 @@ not depend on an unpinned host Node installation.
 
 ### 3. Add or normalize Panda config
 
-Create or update `panda.config.ts`.
+If `panda.config.ts` does not exist, create it from the baseline below.
+
+If `panda.config.ts` already exists, inspect it, report the proposed config
+delta, and ask the user before changing it. Merge only missing compatible
+settings. Preserve existing tokens, presets, `conditions`, include/exclude
+patterns, `globalCss`, output paths, and project-specific extraction behavior
+unless the user approves changing them.
 
 Required baseline:
 
@@ -97,9 +129,12 @@ Use exactly one root stylesheet for Panda layers.
 
 For Vite SPA/Data mode:
 
-1. Create or update a root CSS file such as `src/App.css`.
-2. Import it once from the app entry.
-3. Keep Panda layer order explicit:
+1. If the root CSS file does not exist, create one such as `src/App.css`.
+2. If the root CSS file already exists, inspect it, report the proposed Panda
+   layer addition, and ask the user before changing it.
+3. Import it once from the app entry. If the app entry already exists, inspect
+   it and ask the user before adding or changing imports.
+4. Keep Panda layer order explicit:
 
 ```css
 @layer reset, third-party, base, tokens, recipes, utilities;

--- a/config/claudius/skills/setup-pandacss/skill.yaml
+++ b/config/claudius/skills/setup-pandacss/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-python-lint/assets/pyproject.ruff.toml.template
+++ b/config/claudius/skills/setup-python-lint/assets/pyproject.ruff.toml.template
@@ -80,8 +80,6 @@ select = [
 
 ignore = [
   # ── Intentional relaxations ─────────────────────────────────────────────
-  "ANN101",   # deprecated — self type annotation
-  "ANN102",   # deprecated — cls type annotation
   "COM812",   # trailing comma — conflicts with formatter
   "ISC001",   # implicit string concat — conflicts with formatter
   "TD003",    # TODO issue link — too noisy for most teams

--- a/config/claudius/skills/setup-python-lint/instructions.md
+++ b/config/claudius/skills/setup-python-lint/instructions.md
@@ -13,6 +13,32 @@ directory and detect the Python version from `pyproject.toml` `[project]`
 `requires-python`, `.python-version`, or `runtime.txt`. If none can be
 detected, ask the user.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have a `pyproject.toml` in the root. If not, tell the user
@@ -51,21 +77,34 @@ manager.
 
 ### 2. Add Ruff and mypy configuration to `pyproject.toml`
 
-If `[tool.ruff]` already exists in `pyproject.toml`, go to Step 3.
+Inspect `pyproject.toml` for Ruff and mypy sections independently. Do not skip
+mypy setup just because Ruff is already configured, and do not replace existing
+project-specific Ruff or mypy settings wholesale.
 
-Add the configuration sections from
-[pyproject.ruff.toml.template](assets/pyproject.ruff.toml.template) to
-`pyproject.toml`. Replace the following placeholders:
+If all relevant Ruff sections are missing, add the Ruff-related sections from
+[pyproject.ruff.toml.template](assets/pyproject.ruff.toml.template). If
+`[tool.ruff]` already exists, leave existing Ruff configuration in place and
+verify it in Step 3.
+
+If `[tool.mypy]` is missing, add the mypy-related sections from
+[pyproject.ruff.toml.template](assets/pyproject.ruff.toml.template), including
+`[tool.mypy]` and any `[[tool.mypy.overrides]]` blocks. If `[tool.mypy]` already
+exists, leave existing mypy configuration in place and verify it in Step 3.
+
+Replace the following placeholders in any sections you add:
 
 | Placeholder | Value | Source |
 |---|---|---|
-| `__TARGET_VERSION__` | e.g. `"py312"` | Python version from `$ARGUMENTS`, formatted as `pyNN` |
-| `__MYPY_PYTHON_VERSION__` | e.g. `"3.12"` | Python version from `$ARGUMENTS` |
-| `__PACKAGE_NAME__` | e.g. `"myapp"` | Package name from `$ARGUMENTS` |
+| `__TARGET_VERSION__` | e.g. `py312` | Python version from `$ARGUMENTS`, formatted as `pyNN` |
+| `__MYPY_PYTHON_VERSION__` | e.g. `3.12` | Python version from `$ARGUMENTS` |
+| `__PACKAGE_NAME__` | e.g. `myapp` | Package name from `$ARGUMENTS` |
+
+Use unquoted replacement values. The template already includes TOML quotes around
+these placeholders.
 
 ### 3. Verify strict configuration
 
-If `[tool.ruff]` already existed, verify the following critical settings. If
+Verify the following critical settings for existing or merged configuration. If
 any are missing or weaker, inform the user of the discrepancies. Do NOT
 overwrite. Let the user decide.
 

--- a/config/claudius/skills/setup-python-lint/skill.yaml
+++ b/config/claudius/skills/setup-python-lint/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: '[package name and Python target version, e.g. "myapp 3.12"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-quality-profile/instructions.md
+++ b/config/claudius/skills/setup-quality-profile/instructions.md
@@ -15,6 +15,32 @@ An optional suffix may provide `<primary-owner>[,<security-contact>]`, for examp
 - `tofu-infra,@example/infrastructure`
 - `polyglot-oss,@example/maintainers,@example/security`
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Profile References
 
 Read the matching profile reference before changing anything:
@@ -71,7 +97,7 @@ naming surface for the core `CI - Lint` workflow.
 Run `/setup-rails-api`.
 
 Then run `/setup-typed-eslint-monorepo` for the frontend and package surfaces that need more than
-Biome.
+Biome, passing `profile=rails-monorepo`.
 
 If the repo also has plain TypeScript packages without framework-specific linting needs, use
 `/setup-ts-typecheck` and optionally `/setup-biome` selectively for those simpler surfaces.
@@ -101,9 +127,9 @@ Apply the matching skills only for real surfaces:
 - Generic Ruby (`Gemfile` or `gems.rb`, outside Rails-monorepo scope):
   `/setup-ruby-lint`
 - TypeScript:
-  use `/setup-typed-eslint-monorepo` for framework-heavy, browser-extension,
-  GraphQL, security-sensitive, or functional-rule-heavy surfaces; otherwise use
-  `/setup-ts-typecheck` and optionally `/setup-biome`
+  use `/setup-typed-eslint-monorepo profile=polyglot-oss` for framework-heavy,
+  browser-extension, GraphQL, security-sensitive, or functional-rule-heavy
+  surfaces; otherwise use `/setup-ts-typecheck` and optionally `/setup-biome`
 
 If the Ruby surface also uses Sorbet, layer `/setup-sorbet` after
 `/setup-ruby-lint`.

--- a/config/claudius/skills/setup-quality-profile/references/polyglot-oss.md
+++ b/config/claudius/skills/setup-quality-profile/references/polyglot-oss.md
@@ -102,6 +102,13 @@ Preferred hook names:
 - `commitlint`
 - `commitlint-pre-push`
 
+Component skills may still install lower-level tool hooks when they are clearer
+and already established, for example `cargo-fmt-check`,
+`cargo-clippy-strict`, `ruff-check`, `ruff-format-check`, `mypy-check`, and
+`tsc-noEmit`. Use the language-level names above for aggregate wrapper hooks or
+branch-protection-facing check names; do not rename existing component hook IDs
+solely for profile aesthetics.
+
 Use stronger domain-oriented hook names only when the repository already has a
 clear surface contract that is better than language-level naming.
 
@@ -131,7 +138,7 @@ The Haskell baseline should include:
 The Lean baseline should include:
 
 - `lake build`
-- `lake lint --clippy` by default
+- `lake lint` when a project lint driver is configured
 - preservation of project-specific lint drivers or custom Lake lint executables
 
 Formatting stays project-specific unless the repository already exposes a

--- a/config/claudius/skills/setup-quality-profile/skill.yaml
+++ b/config/claudius/skills/setup-quality-profile/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: '[profile][,<primary-owner>[,<security-contact>]]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rails-api/instructions.md
+++ b/config/claudius/skills/setup-rails-api/instructions.md
@@ -2,6 +2,32 @@
 
 Set up a complete quality stack for a Rails API project. This skill orchestrates the following individual skills in order.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Execution Order
 
 Apply each skill in the following order. For each step, follow the instructions defined in that skill. If a skill's prerequisites are already satisfied (e.g. gems already exist), skip the redundant parts but still verify correctness.

--- a/config/claudius/skills/setup-rails-api/skill.yaml
+++ b/config/claudius/skills/setup-rails-api/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rails-ci/assets/ci.yml.template
+++ b/config/claudius/skills/setup-rails-ci/assets/ci.yml.template
@@ -3,7 +3,11 @@ name: CI - Rails
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches:
+      - "**"
+
+permissions:
+  contents: read
 
 jobs:
   scan_ruby:
@@ -12,27 +16,48 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # actions/checkout v4 resolved on 2026-05-21.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        # ruby/setup-ruby v1 branch resolved on 2026-05-21.
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
         with:
-          ruby-version: .ruby-version
+          ruby-version: __RUBY_VERSION__
           bundler-cache: true
 
-      # Security and consistency steps go here (see step 3)
+      # Security and consistency steps go here (see step 4)
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # actions/checkout v4 resolved on 2026-05-21.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        # ruby/setup-ruby v1 branch resolved on 2026-05-21.
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
         with:
-          ruby-version: .ruby-version
+          ruby-version: __RUBY_VERSION__
           bundler-cache: true
 
-      # Lint and type check steps go here (see step 3)
+      # Lint and type check steps go here (see step 4)
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        # actions/checkout v4 resolved on 2026-05-21.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up Ruby
+        # ruby/setup-ruby v1 branch resolved on 2026-05-21.
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
+        with:
+          ruby-version: __RUBY_VERSION__
+          bundler-cache: true
+
+      # Test setup and test command go here (see step 4)

--- a/config/claudius/skills/setup-rails-ci/instructions.md
+++ b/config/claudius/skills/setup-rails-ci/instructions.md
@@ -2,6 +2,32 @@
 
 Generate a GitHub Actions CI workflow by reading the project's `Gemfile` to determine which quality tools are available.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Read the project's `Gemfile`
@@ -12,22 +38,56 @@ Determine which of the following tools are present:
 - `bundler-audit`
 - `database_consistency`
 - `rubocop`
+- `rspec-rails`
+- `simplecov`
 - `sorbet`
 
-### 2. Create the CI workflow
+### 2. Determine the Ruby version
 
-Create `.github/workflows/ci.yml` using [ci.yml.template](assets/ci.yml.template) as the base. The template has two jobs:
+Before creating the workflow, infer the Ruby version from the first reliable source available:
+
+1. `.ruby-version`
+2. `.tool-versions`
+3. `mise.toml`
+4. `Gemfile` or `gems.rb` `ruby` declaration
+
+Use `.ruby-version` as the workflow value only when that file exists. Otherwise use the inferred exact version string, for example `3.3.6`. If the version cannot be inferred confidently, ask the user before creating the workflow. Do not leave the `__RUBY_VERSION__` placeholder in `.github/workflows/ci.yml`.
+
+### 3. Create or update the CI workflow
+
+If `.github/workflows/ci.yml` does not exist, create it using
+[ci.yml.template](assets/ci.yml.template) as the base.
+
+If `.github/workflows/ci.yml` already exists, inspect the current workflow and
+ask the user before changing it. Merge missing jobs, permissions, action pinning,
+and tool steps into the existing structure. Do not replace the workflow
+wholesale unless the user explicitly approves that replacement. Preserve
+project-specific triggers, services, matrices, environment variables, path
+filters, concurrency, and permissions unless they conflict with the requested CI
+policy.
+
+The template has three jobs:
 
 - **`scan_ruby`** — Security and consistency checks
 - **`lint`** — Code style and type checking
+- **`test`** — Rails test execution and coverage gates
 
-### 3. Populate jobs based on installed tools
+Replace every `__RUBY_VERSION__` placeholder with the value from Step 2.
+Keep the workflow-level `permissions: contents: read` unless the project adds a
+step that demonstrably needs a broader permission.
+
+The template pins `actions/checkout` and `ruby/setup-ruby` by full commit SHA.
+When upgrading either action, re-resolve the desired tag or branch with
+`git ls-remote`, then update both the SHA and the adjacent resolved-date
+comment. Do not switch these actions back to mutable tag references.
+
+### 4. Populate jobs based on installed tools
 
 **`scan_ruby` job** — add steps for each tool present:
 
 | Tool | Step |
 |---|---|
-| `brakeman` | `bin/brakeman --no-pager` |
+| `brakeman` | `bin/brakeman --no-pager` when `bin/brakeman` exists; otherwise `bundle exec brakeman --no-pager` |
 | `bundler-audit` | `bundle exec bundler-audit check --update` |
 | `database_consistency` | `bundle exec database_consistency` |
 
@@ -35,14 +95,23 @@ Create `.github/workflows/ci.yml` using [ci.yml.template](assets/ci.yml.template
 
 | Tool | Step |
 |---|---|
-| `rubocop` | `bin/rubocop -f github` |
+| `rubocop` | `bin/rubocop -f github` when `bin/rubocop` exists; otherwise `bundle exec rubocop -f github` |
 | `sorbet` | `bundle exec srb tc` |
+
+**`test` job** — always add a Rails test step:
+
+| Evidence | Step |
+|---|---|
+| `rspec-rails` in `Gemfile` | `bundle exec rspec` |
+| otherwise | `bin/rails test` |
+
+If `simplecov` is present, the test command is the coverage gate. Do not add a separate coverage-only command unless the project already has one.
 
 If a tool is not in the Gemfile, do NOT add its step.
 
-### 4. Handle `database_consistency` specially
+### 5. Handle database setup specially
 
-`database_consistency` requires a running database. If it's present, the `scan_ruby` job needs database setup. Add the following to the job:
+`database_consistency` requires a running database. If it's present, the `scan_ruby` job needs database setup. Add the following to that job:
 
 ```yaml
 services:
@@ -69,11 +138,15 @@ And add a database setup step before the consistency check:
   run: bin/rails db:setup
 ```
 
-If `database_consistency` is NOT present, do NOT add the database service or setup step.
+If the test job needs a database, add the same database service and setup step to the `test` job before the test command. Use the project's actual adapter and CI database URL; do not force PostgreSQL for SQLite-only projects.
+
+If `database_consistency` is NOT present and the test job does not need a database service, do NOT add the database service or setup step.
 
 ## Important Notes
 
-- If `.github/workflows/ci.yml` already exists, ask the user before overwriting.
-- This workflow uses `ruby/setup-ruby@v1` with `bundler-cache: true` for fast gem installation.
-- The Ruby version is read from `.ruby-version`.
+- If `.github/workflows/ci.yml` already exists, merge/update it in place; ask
+  the user before any broad replacement or policy-changing rewrite.
+- The template runs push CI for all branches. Do not narrow it to `main` unless the repository explicitly requires that policy.
+- This workflow uses SHA-pinned `ruby/setup-ruby` with `bundler-cache: true` for fast gem installation.
+- The Ruby version must match the project source of truth; `.ruby-version` is common but not mandatory.
 - This CI is for the Rails app itself. The Nix-based root `lint.yml` (generated by `/setup-nix-ci-lint`) handles pre-commit hooks separately.

--- a/config/claudius/skills/setup-rails-ci/skill.yaml
+++ b/config/claudius/skills/setup-rails-ci/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rails-db-safety/instructions.md
+++ b/config/claudius/skills/setup-rails-db-safety/instructions.md
@@ -2,6 +2,32 @@
 
 Add strong_migrations (migration safety) and database_consistency (model-DB integrity) to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Add gems to `Gemfile`
@@ -20,15 +46,27 @@ gem 'database_consistency', require: false
 
 ### 2. Create `config/initializers/strong_migrations.rb`
 
-Create the file using [strong_migrations.rb.template](assets/strong_migrations.rb.template). Set `target_postgresql_version` to match the project's PostgreSQL version.
+If `config/initializers/strong_migrations.rb` does not exist, create it using
+[strong_migrations.rb.template](assets/strong_migrations.rb.template). Set
+`target_postgresql_version` to match the project's PostgreSQL version.
+
+If the initializer already exists, inspect it and ask the user before changing
+it. Preserve existing `start_after`, custom checks, safety overrides, and
+database-version policy unless the user approves a change.
+
+Replace `__PG_VERSION__` with the PostgreSQL major version, or the major/minor version if the project already tracks that level of precision. Infer it from `config/database.yml`, Docker Compose service images, devcontainer settings, or deployment manifests. If it cannot be inferred confidently, ask the user before creating the initializer. Do not leave the `__PG_VERSION__` placeholder in Ruby code.
 
 ### 3. Create `.database_consistency.yml`
 
-Create the file in the Rails root:
+If `.database_consistency.yml` does not exist, create the file in the Rails root:
 
 ```yaml
 enabled: true
 ```
+
+If `.database_consistency.yml` already exists, inspect it and ask the user before
+changing it. Do not remove project-specific ignore lists, severity settings, or
+custom checks.
 
 ## Important Notes
 

--- a/config/claudius/skills/setup-rails-db-safety/skill.yaml
+++ b/config/claudius/skills/setup-rails-db-safety/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rails-security/instructions.md
+++ b/config/claudius/skills/setup-rails-security/instructions.md
@@ -2,6 +2,32 @@
 
 Add Brakeman (application security) and bundler-audit (dependency vulnerability) scanning to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Add gems to `Gemfile`

--- a/config/claudius/skills/setup-rails-security/skill.yaml
+++ b/config/claudius/skills/setup-rails-security/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rails-testing/instructions.md
+++ b/config/claudius/skills/setup-rails-testing/instructions.md
@@ -2,9 +2,40 @@
 
 Add SimpleCov with branch coverage tracking to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
-### 1. Add gems to `Gemfile`
+### 1. Detect the test framework
+
+Use RSpec when `rspec-rails` is present in `Gemfile` or the project has a
+`spec/` directory. Otherwise use Minitest.
+
+### 2. Add gems to `Gemfile`
 
 Add to the `development, test` group. Do NOT duplicate gems that already exist.
 
@@ -12,11 +43,19 @@ Add to the `development, test` group. Do NOT duplicate gems that already exist.
 gem 'simplecov', require: false
 ```
 
-### 2. Create or update `test/test_helper.rb`
+### 3. Install SimpleCov in the test boot path
+
+For Minitest, create or update `test/test_helper.rb`.
 
 If `test/test_helper.rb` does not exist, create it using [test_helper.rb.template](assets/test_helper.rb.template).
 
-If it already exists, add the SimpleCov block at the very top of the file (before any other requires):
+If it already exists, first check whether SimpleCov is already configured in
+`test/test_helper.rb`, `spec/spec_helper.rb`, or `spec/rails_helper.rb`. If it is
+already configured, do not add a duplicate block; inspect the current thresholds
+and ask the user before changing them.
+
+If SimpleCov is not configured, add the SimpleCov block at the very top of the
+selected helper file (before any other requires):
 
 ```ruby
 require 'simplecov'
@@ -26,13 +65,26 @@ SimpleCov.start 'rails' do
 end
 ```
 
-### 3. Add `coverage/` to `.gitignore`
+For RSpec, add the same SimpleCov block at the very top of
+`spec/spec_helper.rb` or `spec/rails_helper.rb`, before any other requires or
+application code. Prefer `spec/spec_helper.rb` when it exists and the project's
+spec files load it; otherwise use `spec/rails_helper.rb`.
 
-If not already present, add `coverage/` to `.gitignore`.
+If the selected RSpec helper file does not exist, create the minimal helper
+needed by the project and place the SimpleCov block before requiring Rails or
+RSpec support files. Do not add SimpleCov only to `test/test_helper.rb` in an
+RSpec project.
+
+### 4. Add `coverage/` to `.gitignore`
+
+If `.gitignore` exists, check whether it already contains `coverage/`. If not,
+show the proposed `coverage/` addition and ask the user before appending it.
+
+If `.gitignore` does not exist, create it with `coverage/` as the sole entry.
 
 ## Important Notes
 
-- SimpleCov MUST be required at the very top of `test_helper.rb`, before `rails/test_help` or any application code is loaded. Otherwise, coverage will be incomplete.
+- SimpleCov MUST be required at the very top of `test/test_helper.rb`, `spec/spec_helper.rb`, or `spec/rails_helper.rb`, before `rails/test_help`, `rails_helper`, or any application code is loaded. Otherwise, coverage will be incomplete.
 - `enable_coverage :branch` enables branch coverage in addition to line coverage.
 - The thresholds (line: 90%, branch: 80%) are enforced from the start. Setting them early prevents coverage from degrading as the codebase grows.
-- If the project uses RSpec instead of Minitest, the setup goes in `spec/spec_helper.rb` or `spec/rails_helper.rb` instead.
+- In CI, `bundle exec rspec` or `bin/rails test` enforces coverage as long as SimpleCov is loaded by the relevant helper before application boot.

--- a/config/claudius/skills/setup-rails-testing/skill.yaml
+++ b/config/claudius/skills/setup-rails-testing/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-repository-baseline/instructions.md
+++ b/config/claudius/skills/setup-repository-baseline/instructions.md
@@ -44,6 +44,32 @@ Create or fill gaps in the following baseline files:
 - Preserve existing project-specific content. Merge missing sections instead of
   overwriting files wholesale.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Inspect repository state
@@ -54,6 +80,19 @@ Determine these values before editing:
 - default branch
 - primary owner for `CODEOWNERS`
 - security contact for `SECURITY.md`
+
+Replace template placeholders with the inferred or confirmed values:
+
+| Placeholder | Replacement |
+|---|---|
+| `__REPOSITORY_NAME__` | repository name |
+| `__DEFAULT_BRANCH__` | default branch |
+| `__PRIMARY_OWNER__` | GitHub user or team owner for fallback `CODEOWNERS` |
+| `__SECURITY_CONTACT__` | non-public vulnerability reporting contact |
+
+Do not leave any `__REPOSITORY_NAME__`, `__DEFAULT_BRANCH__`,
+`__PRIMARY_OWNER__`, or `__SECURITY_CONTACT__` placeholders in generated
+files.
 
 Inspect existing files first. If any of the target files already exist, preserve
 project-specific details and only fill gaps.
@@ -74,7 +113,9 @@ fallback owner.
 If `CONTRIBUTING.md` does not exist, create it from
 [CONTRIBUTING.md.template](assets/CONTRIBUTING.md.template).
 
-If it already exists, ensure it covers these baseline policies:
+If it already exists, inspect it, report missing baseline policy items, and ask
+the user before changing it. When approved, merge only the missing baseline
+coverage:
 
 - how to propose changes and discuss larger changes early
 - branch-from-default-branch workflow
@@ -92,7 +133,9 @@ lefthook, plain scripts, or no local automation.
 If `SECURITY.md` does not exist, create it from
 [SECURITY.md.template](assets/SECURITY.md.template).
 
-If it already exists, ensure it includes:
+If it already exists, inspect it, report missing baseline security policy items,
+and ask the user before changing it. When approved, merge only the missing
+baseline coverage:
 
 - a clear non-public reporting path
 - supported versions or branches
@@ -111,8 +154,9 @@ Do NOT leave placeholder contact values in the final file.
 If `CHANGELOG.md` does not exist, create it from
 [CHANGELOG.md.template](assets/CHANGELOG.md.template).
 
-If it already exists, ensure there is an `Unreleased` section and that the file
-is appropriate for contributor-facing release notes.
+If it already exists, inspect it, report whether `Unreleased` or
+contributor-facing release-note structure is missing, and ask the user before
+changing it.
 
 Prefer Keep a Changelog structure unless the repository already has another
 clear changelog convention.
@@ -122,7 +166,9 @@ clear changelog convention.
 If `docs/runbooks/release.md` does not exist, create it from
 [release.md.template](assets/release.md.template).
 
-If it already exists, ensure it covers:
+If it already exists, inspect it, report missing release-process items, and ask
+the user before changing it. When approved, merge only the missing baseline
+coverage:
 
 - release preconditions
 - changelog and version preparation
@@ -142,6 +188,7 @@ If the file does not exist, create it from
 
 If it exists:
 
+- inspect it and ask the user before changing it
 - preserve granular path ownership rules
 - ensure there is a fallback owner entry for `*`
 - avoid removing stricter existing ownership patterns
@@ -151,7 +198,8 @@ If it exists:
 If the file does not exist, create it from
 [pull_request_template.md.template](assets/pull_request_template.md.template).
 
-If it exists, ensure it asks for:
+If it exists, inspect it, report missing PR-description fields, and ask the user
+before changing it. When approved, merge only the missing fields:
 
 - summary
 - verification

--- a/config/claudius/skills/setup-repository-baseline/skill.yaml
+++ b/config/claudius/skills/setup-repository-baseline/skill.yaml
@@ -10,4 +10,4 @@ targets:
     invocation: manual
     argument-hint: '[optional: "<primary-owner>[,<security-contact>]"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rubocop/instructions.md
+++ b/config/claudius/skills/setup-rubocop/instructions.md
@@ -2,6 +2,32 @@
 
 Add RuboCop with Rails-oriented plugins and a strict configuration to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Add gems to `Gemfile`
@@ -17,11 +43,29 @@ gem 'rubocop-rake', require: false
 gem 'rubocop-thread_safety', require: false
 ```
 
-### 2. Create `.rubocop.yml`
+### 2. Infer the Ruby target version
 
-Create the file using [rubocop.yml.template](assets/rubocop.yml.template). If `.rubocop.yml` already exists, merge missing plugins and rules into it without removing existing configuration.
+Before creating `.rubocop.yml`, infer the Ruby version from the first reliable source available:
 
-### 3. Create `bin/rubocop` wrapper (optional)
+1. `.ruby-version`
+2. `.tool-versions`
+3. `mise.toml`
+4. `Gemfile` or `gems.rb` `ruby` declaration
+
+Use the inferred major/minor version, for example `3.3` from `3.3.6`. If the version cannot be inferred confidently, ask the user before creating the file. Do not leave the `__RUBY_VERSION__` placeholder in `.rubocop.yml`.
+
+### 3. Create `.rubocop.yml`
+
+If `.rubocop.yml` does not exist, create it using
+[rubocop.yml.template](assets/rubocop.yml.template), replacing
+`__RUBY_VERSION__` with the inferred target version.
+
+If `.rubocop.yml` already exists, inspect it and ask the user before changing
+it. Merge only missing compatible plugins and rules; Do NOT duplicate plugin
+entries or rule blocks. Preserve existing plugin order, inheritance, excludes,
+and project-specific settings unless the user approves changing them.
+
+### 4. Create `bin/rubocop` wrapper (optional)
 
 If `bin/rubocop` does not exist, create it:
 

--- a/config/claudius/skills/setup-rubocop/skill.yaml
+++ b/config/claudius/skills/setup-rubocop/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-ruby-lint/assets/rubocop.yml.template
+++ b/config/claudius/skills/setup-ruby-lint/assets/rubocop.yml.template
@@ -1,7 +1,7 @@
 plugins:
   - rubocop-performance
   - rubocop-thread_safety
-__OPTIONAL_PLUGINS__
+  # __OPTIONAL_PLUGINS__
 
 AllCops:
   NewCops: enable

--- a/config/claudius/skills/setup-ruby-lint/instructions.md
+++ b/config/claudius/skills/setup-ruby-lint/instructions.md
@@ -8,6 +8,32 @@ Minitest support when the repository actually uses those surfaces.
 If it is omitted, infer it from `.ruby-version`, `.tool-versions`, `mise.toml`,
 `Gemfile`, or `gems.rb`. If it still cannot be inferred safely, ask the user.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have a root `Gemfile` or `gems.rb`.
@@ -57,10 +83,26 @@ if it does not exist.
 Replace:
 
 - `__RUBY_VERSION__`
-- `__OPTIONAL_PLUGINS__`
+- the full `  # __OPTIONAL_PLUGINS__` line
 
-If `.rubocop.yml` already exists, merge missing baseline rules and plugins
-without removing existing project-specific configuration.
+Use this replacement when both optional surfaces are detected:
+
+```yaml
+  - rubocop-rake
+  - rubocop-minitest
+```
+
+If only one optional surface is detected, replace the line with only that plugin.
+If no optional surface is detected, remove the placeholder line entirely.
+
+Do not leave `__OPTIONAL_PLUGINS__` in the generated `.rubocop.yml`.
+
+If `.rubocop.yml` already exists, inspect it and ask the user before changing
+it. Merge only missing compatible baseline rules and plugins.
+
+Do NOT duplicate plugin entries or rule blocks. Preserve existing plugin order,
+inheritance, excludes, and project-specific configuration unless the user
+approves changing them.
 
 ### 4. Create `bin/rubocop` wrapper (optional)
 

--- a/config/claudius/skills/setup-ruby-lint/skill.yaml
+++ b/config/claudius/skills/setup-ruby-lint/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: '[ruby_version, e.g. "3.3"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-rust-lint/instructions.md
+++ b/config/claudius/skills/setup-rust-lint/instructions.md
@@ -4,6 +4,32 @@ Add `cargo fmt` and strict `cargo clippy` checks for a Cargo project. This
 skill standardizes on the community formatter and a strict Clippy gate with
 check-only hooks.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have a root `Cargo.toml`.

--- a/config/claudius/skills/setup-rust-lint/skill.yaml
+++ b/config/claudius/skills/setup-rust-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
   claude-code:
     invocation: manual
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-secrets-scan/instructions.md
+++ b/config/claudius/skills/setup-secrets-scan/instructions.md
@@ -2,6 +2,32 @@
 
 Add secret detection hooks to the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix`. If not, tell the user to run `/setup-git-hooks` first.
@@ -22,7 +48,11 @@ Hooks added:
 
 ### 2. Check for `.gitleaks.toml`
 
-If `.gitleaks.toml` exists in the project root, append `--config .gitleaks.toml` to both gitleaks and gitleaks-full-scan entry commands. If it does not exist, use the default configuration.
+If `.gitleaks.toml` exists in the project root, ensure both gitleaks and
+gitleaks-full-scan entry commands include exactly one `--config .gitleaks.toml`.
+Do not append a duplicate flag when it is already present. If a different
+gitleaks config path is already configured, ask the user before changing it. If
+`.gitleaks.toml` does not exist, use the default configuration.
 
 ## Important Notes
 

--- a/config/claudius/skills/setup-secrets-scan/skill.yaml
+++ b/config/claudius/skills/setup-secrets-scan/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-shell-lint/instructions.md
+++ b/config/claudius/skills/setup-shell-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Add shellcheck and shfmt hooks to the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix`. If not, tell the user to run `/setup-git-hooks` first.

--- a/config/claudius/skills/setup-shell-lint/skill.yaml
+++ b/config/claudius/skills/setup-shell-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-sorbet/instructions.md
+++ b/config/claudius/skills/setup-sorbet/instructions.md
@@ -2,6 +2,32 @@
 
 Add Sorbet type checking with Tapioca RBI generation and rubocop-sorbet linting to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
 ### 1. Add gems to `Gemfile`
@@ -22,7 +48,11 @@ gem 'sorbet-runtime'
 
 ### 2. Add `rubocop-sorbet` to `.rubocop.yml`
 
-If `.rubocop.yml` exists, add `rubocop-sorbet` to the `plugins` list. If it does not exist, tell the user to run `/setup-rubocop` first.
+If `.rubocop.yml` does not exist, tell the user to run `/setup-rubocop` first.
+
+If `.rubocop.yml` exists, inspect it and ask the user before changing it. Add
+`rubocop-sorbet` to the `plugins` list only if it is missing, and preserve the
+existing plugin order and project-specific RuboCop settings.
 
 ### 3. Create `sorbet/config`
 

--- a/config/claudius/skills/setup-sorbet/skill.yaml
+++ b/config/claudius/skills/setup-sorbet/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-sql-lint/instructions.md
+++ b/config/claudius/skills/setup-sql-lint/instructions.md
@@ -10,6 +10,32 @@ Add SQLFluff linting and formatting checks for `.sql` files. This skill standard
 
 If no argument is given, use the defaults above.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - `sqlfluff` must be available in the environment.
@@ -61,7 +87,12 @@ Hook added:
 
 ### 2. Create `.sqlfluff`
 
-Create `.sqlfluff` in the project root using the template in [sqlfluff.template](assets/sqlfluff.template).
+If `.sqlfluff` does not exist, create it in the project root using the template
+in [sqlfluff.template](assets/sqlfluff.template).
+
+If `.sqlfluff` already exists, inspect it and ask the user before changing it.
+Merge only missing baseline values that are compatible with the current dialect,
+templater, and project-specific rule choices. Do not replace the file wholesale.
 
 Replace the placeholders:
 

--- a/config/claudius/skills/setup-sql-lint/skill.yaml
+++ b/config/claudius/skills/setup-sql-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: '[dialect=postgres templater=raw max_line_length=100]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-stylelint/assets/stylelintrc.yml.template
+++ b/config/claudius/skills/setup-stylelint/assets/stylelintrc.yml.template
@@ -24,9 +24,8 @@ rules:
       - /^font/
       - z-index
       - border-radius
-    - ignoreValues:
-        "": ["currentColor", "inherit", "transparent", "initial", "none", "0"]
-      expandShorthandProperties: true
+    - ignoreValues: ["currentColor", "inherit", "transparent", "initial", "none", "0"]
+      expandShorthand: true
 
   # Disallow redundant values
   shorthand-property-no-redundant-values: true
@@ -40,7 +39,7 @@ rules:
   scss/at-extend-no-missing-placeholder: null
 
   # Enforce @use over @import (modern SCSS modules)
-  scss/at-import-no-partial-leading-underscore: true
+  scss/load-no-partial-leading-underscore: true
   scss/no-global-function-names: true
 
   # ── Naming ──────────────────────────────────────────

--- a/config/claudius/skills/setup-stylelint/instructions.md
+++ b/config/claudius/skills/setup-stylelint/instructions.md
@@ -2,25 +2,64 @@
 
 Add stylelint with strict, functional-style CSS/SCSS rules to the project.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Steps
 
-### 1. Install npm packages
+### 1. Install packages
 
-Run the following to install stylelint and plugins:
+Use the package manager already used by the project. Do not switch package managers.
+
+Examples:
 
 ```bash
+npm install --save-dev stylelint stylelint-config-standard-scss stylelint-order stylelint-declaration-strict-value
+pnpm add -D stylelint stylelint-config-standard-scss stylelint-order stylelint-declaration-strict-value
 yarn add -D stylelint stylelint-config-standard-scss stylelint-order stylelint-declaration-strict-value
+bun add -d stylelint stylelint-config-standard-scss stylelint-order stylelint-declaration-strict-value
 ```
 
-If the project uses `npm` instead of `yarn`, use `npm install --save-dev` instead.
+Do NOT run these commands automatically. The user must choose or confirm the package manager.
 
 ### 2. Create `.stylelintrc.yml`
 
-Create the file using [stylelintrc.yml.template](assets/stylelintrc.yml.template).
+If `.stylelintrc.yml` does not exist, create it using
+[stylelintrc.yml.template](assets/stylelintrc.yml.template).
+
+If a Stylelint config already exists (`.stylelintrc*` or `stylelint.config.*`),
+inspect it and ask the user before changing it. Merge missing rules and plugins
+without replacing project-specific syntax, ignore patterns, or framework
+overrides.
 
 ### 3. Add lint script to `package.json`
 
-Add the following to the `scripts` section in `package.json`:
+Add the following to the `scripts` section in `package.json` only when the script
+names are absent. Do not overwrite existing scripts with the same names; report
+the mismatch and ask the user how to proceed.
 
 ```json
 "lint:css": "stylelint 'app/assets/stylesheets/**/*.{css,scss}'",
@@ -29,12 +68,19 @@ Add the following to the `scripts` section in `package.json`:
 
 ### 4. Add to CI
 
-If `.github/workflows/ci.yml` exists, add the following step to the `lint` job:
+If `.github/workflows/ci.yml` exists, inspect it and ask the user before
+changing it. Add the following step to the `lint` job only when there is no
+equivalent stylesheet lint step already present. Do NOT duplicate an existing
+stylelint or `lint:css` step. Preserve the existing workflow triggers, jobs,
+dependency setup, package-manager setup, and job structure unless the user
+approves changing them:
 
 ```yaml
 - name: Lint stylesheets
-  run: yarn lint:css
+  run: <package-manager-run-command> lint:css
 ```
+
+Use the project's package manager command, for example `npm run lint:css`, `pnpm lint:css`, `yarn lint:css`, or `bun run lint:css`. Ensure dependencies are installed earlier in the workflow.
 
 ## Important Notes
 
@@ -43,4 +89,4 @@ If `.github/workflows/ci.yml` exists, add the following step to the `lint` job:
 - `stylelint-declaration-strict-value` forces variables/functions for colors, fonts, and sizes — preventing magic values and promoting design tokens.
 - The config enforces functional/compositional patterns: no `@extend`, prefer `@mixin`/`@use`, no `!important`, no ID selectors.
 - Max nesting depth of 3 and max selector compound count of 3 keep specificity flat.
-- Run `yarn lint:css:fix` to auto-fix fixable violations.
+- Run the matching package-manager command for `lint:css:fix` to auto-fix fixable violations.

--- a/config/claudius/skills/setup-stylelint/skill.yaml
+++ b/config/claudius/skills/setup-stylelint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-tftpl-lint/assets/tftpl-validate.sh.template
+++ b/config/claudius/skills/setup-tftpl-lint/assets/tftpl-validate.sh.template
@@ -39,17 +39,34 @@ if [[ ${#files[@]} -eq 0 ]]; then
   exit 0
 fi
 
+hcl_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  value="${value//$'\r'/\\r}"
+  value="${value//$'\t'/\\t}"
+  printf '"%s"' "${value}"
+}
+
 for file in "${files[@]}"; do
+  if [[ ! -f "${file}" && -f "${root}/${file}" ]]; then
+    file="${root}/${file}"
+  fi
   if [[ ! -f "${file}" ]]; then
-    if [[ -f "${root}/${file}" ]]; then
-      file="${root}/${file}"
-    else
-      echo "Template file not found: ${file}" >&2
-      exit 1
-    fi
+    echo "Template file not found: ${file}" >&2
+    exit 1
+  fi
+  if [[ "${file}" != /* ]]; then
+    file="$(cd "$(dirname "${file}")" && pwd)/$(basename "${file}")"
   fi
 
-  "${engine}" console -chdir="${console_dir}" <<TFTPL_EOF
-templatefile("${file}", jsondecode(file("${vars_file}")))
+  file_expr="$(hcl_string "${file}")"
+  vars_expr="$(hcl_string "${vars_file}")"
+  if ! "${engine}" -chdir="${console_dir}" console >/dev/null <<TFTPL_EOF; then
+templatefile(${file_expr}, jsondecode(file(${vars_expr})))
 TFTPL_EOF
+    echo "tftpl-validate: failed to render ${file}" >&2
+    exit 1
+  fi
 done

--- a/config/claudius/skills/setup-tftpl-lint/instructions.md
+++ b/config/claudius/skills/setup-tftpl-lint/instructions.md
@@ -10,6 +10,32 @@ Add a strict validation hook for `.tftpl` files by rendering them with `template
 
 If no argument is given, use the defaults above.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - `tofu` or `terraform` must be available in the environment.
@@ -56,11 +82,23 @@ Hook added:
 
 ### 2. Create `tftpl.vars.json`
 
-Create `tftpl.vars.json` in the project root using the template in [tftpl.vars.json.template](assets/tftpl.vars.json.template). Populate it with all variables required by your templates.
+If `tftpl.vars.json` does not exist, create it in the project root using the
+template in [tftpl.vars.json.template](assets/tftpl.vars.json.template).
+Populate it with all variables required by your templates.
+
+If the variables file already exists, inspect it and ask the user before
+changing it. Merge only missing variables required by the templates; do not
+delete project-specific sample values.
 
 ### 3. Create `scripts/tftpl-validate.sh`
 
-Create `scripts/tftpl-validate.sh` using the template in [tftpl-validate.sh.template](assets/tftpl-validate.sh.template). Make it executable (`chmod +x`).
+If `scripts/tftpl-validate.sh` does not exist, create it using the template in
+[tftpl-validate.sh.template](assets/tftpl-validate.sh.template). Make it
+executable (`chmod +x`).
+
+If the script already exists, inspect it and ask the user before changing it.
+Merge missing validation behavior without replacing project-specific engine,
+console directory, or variable-loading logic unless approved.
 
 The script:
 
@@ -79,5 +117,8 @@ If any template fails to render, fix the syntax or update `tftpl.vars.json`.
 ## Important Notes
 
 - This hook is check-only. Do NOT auto-generate template outputs in hooks or CI.
+- The validation script must discard rendered template stdout. Do NOT print
+  rendered `.tftpl` bodies in pre-commit or CI logs unless the user explicitly
+  asks for a debug run and the output has been reviewed for sensitive values.
 - Keep `tftpl.vars.json` complete and explicit. Missing variables must fail the hook.
 - If templates require module context or providers, run the hook in a directory where console evaluation is valid.

--- a/config/claudius/skills/setup-tftpl-lint/skill.yaml
+++ b/config/claudius/skills/setup-tftpl-lint/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: '[engine=tofu vars_file=tftpl.vars.json console_dir=.]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-tofu-lint/assets/hooks.nix.template
+++ b/config/claudius/skills/setup-tofu-lint/assets/hooks.nix.template
@@ -2,8 +2,9 @@ tofu-format = {
   enable = true;
   name = "tofu-format";
   package = pkgs.opentofu;
-  entry = "${pkgs.opentofu}/bin/tofu fmt";
+  entry = "${pkgs.opentofu}/bin/tofu fmt -check -diff";
   files = "\\.(tf|tfvars)$";
+  pass_filenames = true;
 };
 tflint.enable = true;
 terraform-validate.enable = false;
@@ -85,6 +86,30 @@ hclfmt = {
   enable = true;
   name = "hclfmt";
   package = pkgs.hclfmt;
-  entry = "${pkgs.hclfmt}/bin/hclfmt -w";
+  entry =
+    let
+      hclfmt-check = pkgs.writeScriptBin "hclfmt-check" ''
+        #!/usr/bin/env bash
+        set -euo pipefail
+        temp_dir="$(mktemp -d)"
+        trap 'rm -rf "$temp_dir"' EXIT
+        status=0
+        for file in "$@"; do
+          if [ ! -f "$file" ]; then
+            continue
+          fi
+          formatted="$(mktemp "$temp_dir/hclfmt.XXXXXX")"
+          ${pkgs.hclfmt}/bin/hclfmt "$file" > "$formatted"
+          if ! ${pkgs.diffutils}/bin/cmp -s "$file" "$formatted"; then
+            echo "hclfmt-check: $file is not formatted" >&2
+            ${pkgs.diffutils}/bin/diff -u "$file" "$formatted" >&2 || true
+            status=1
+          fi
+        done
+        exit "$status"
+      '';
+    in
+    "${hclfmt-check}/bin/hclfmt-check";
   files = "\\.hcl$";
+  pass_filenames = true;
 };

--- a/config/claudius/skills/setup-tofu-lint/instructions.md
+++ b/config/claudius/skills/setup-tofu-lint/instructions.md
@@ -2,6 +2,32 @@
 
 Add OpenTofu/Terraform code quality hooks to the project's `flake.nix`.
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have `git-hooks.nix` integrated in `flake.nix`. If not, tell the user to run `/setup-git-hooks` first.
@@ -14,8 +40,8 @@ Add the hooks from [hooks.nix.template](assets/hooks.nix.template) into the `hoo
 
 Hooks added:
 
-- **tofu-format** — Runs `tofu fmt` on `.tf` and `.tfvars` files
-- **hclfmt** — Formats `.hcl` files (e.g. `.terraform.lock.hcl`, Packer configs)
+- **tofu-format** — Runs `tofu fmt -check -diff` on `.tf` and `.tfvars` files
+- **hclfmt** — Checks `.hcl` formatting by comparing `hclfmt` output against the original file without writing changes
 - **tflint** — Terraform/OpenTofu linter for best practices and errors
 - **tofu-validate-no-backend** — Reads root module directories from `.tofu-root-modules`, requires each root to have `.terraform.lock.hcl`, then runs `tofu init -backend=false -lockfile=readonly` and `tofu validate` for each root module. Runs serially to avoid init conflicts.
 - **terraform-validate** — Explicitly disabled (replaced by tofu-validate-no-backend)
@@ -63,4 +89,4 @@ modules that should have committed provider locks.
 - The hook sets `AWS_EC2_METADATA_DISABLED=true` and uses temporary `TF_CLI_CONFIG_FILE` and
   `TF_DATA_DIR` values to avoid interference from real backends or cached local `.terraform` state
   during validation.
-- Validation hooks should be check-only gates. They may create local `.terraform` working data, but should not rewrite provider locks during CI.
+- Formatting and validation hooks should be check-only gates. They may create local `.terraform` working data, but must not rewrite source files or provider locks during CI.

--- a/config/claudius/skills/setup-tofu-lint/skill.yaml
+++ b/config/claudius/skills/setup-tofu-lint/skill.yaml
@@ -8,4 +8,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-tofu-project/instructions.md
+++ b/config/claudius/skills/setup-tofu-project/instructions.md
@@ -2,7 +2,35 @@
 
 Set up a complete linting, formatting, security scanning, CI, and commit message enforcement stack for an OpenTofu IaC project. This skill orchestrates the following individual skills in order.
 
-**The argument `$ARGUMENTS` is a comma-separated list of allowed commitlint scopes.** If no argument is given, ask the user for the list of scopes.
+**The argument `$ARGUMENTS` is optional** and may provide a comma-separated list
+of allowed commitlint scopes. If no argument is given, run `/setup-commitlint`
+without explicit scopes so it can infer the repository taxonomy.
+
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
 
 ## Execution Order
 
@@ -29,8 +57,10 @@ Add OpenTofu code quality hooks (tofu fmt, hclfmt, tflint, tofu validate).
 ### Step 7: `/setup-iac-security`
 Add IaC security scanning (tfsec, trivy).
 
-### Step 8: `/setup-commitlint $ARGUMENTS`
-Add commitlint with Conventional Commits rules, git hooks, and CI enforcement using the provided scopes.
+### Step 8: `/setup-commitlint`
+Add commitlint with Conventional Commits rules, git hooks, and CI enforcement.
+Pass `$ARGUMENTS` through only when explicit scopes were provided; otherwise let
+`/setup-commitlint` infer and optimize scopes from the repository layout.
 
 ### Step 9: `/setup-nix-ci-lint`
 Generate `.github/workflows/lint.yml` from the flake.nix hook configuration using Determinate Systems actions.
@@ -41,12 +71,14 @@ against the OpenTofu infrastructure profile.
 
 ## After Completion
 
-Summarize what was set up and list any config files the user needs to create:
+Summarize what was set up and list any required config files the user needs to create:
 - `.editorconfig`
-- `.markdownlint.json`
-- `.typos.toml`
 
 Only list files that do not already exist in the project root.
+
+Also mention these optional override files if they do not exist and the project would benefit from custom rules:
+- `.markdownlint.json` — markdownlint uses defaults when this is missing
+- `.typos.toml` — typos uses defaults when this is missing
 
 Also summarize any remaining reproducibility gaps:
 - root modules missing `.terraform.lock.hcl`

--- a/config/claudius/skills/setup-tofu-project/skill.yaml
+++ b/config/claudius/skills/setup-tofu-project/skill.yaml
@@ -5,6 +5,8 @@ description: One-command setup for a new OpenTofu IaC project with full linting,
 targets:
   claude-code:
     invocation: manual
-    argument-hint: '[comma-separated commitlint scopes, e.g. "ci,deps,docs,envs,modules,nix,scripts,security,tooling"]'
+    argument-hint: >-
+      [optional: comma-separated commitlint scopes, e.g.
+      "ci,deps,docs,envs,modules,nix,scripts,security,tooling"]
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-ts-typecheck/instructions.md
+++ b/config/claudius/skills/setup-ts-typecheck/instructions.md
@@ -7,6 +7,32 @@ This skill provides **type checking only**. It does NOT lint or format code — 
 - `/setup-biome` — syntax rules, style, formatting (fast, no type information)
 - `/setup-ts-typecheck` — full type system validation (slower, requires `tsconfig.json`)
 
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
+
 ## Prerequisites
 
 - The project must have a `tsconfig.json` in the root (or a `tsconfig.json` referenced by a root-level config). If not, tell the user to create one first. Do NOT generate `tsconfig.json` — TypeScript configuration is project-specific.

--- a/config/claudius/skills/setup-ts-typecheck/skill.yaml
+++ b/config/claudius/skills/setup-ts-typecheck/skill.yaml
@@ -7,4 +7,4 @@ targets:
     invocation: manual
     argument-hint: "(no arguments required)"
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/setup-typed-eslint-monorepo/instructions.md
+++ b/config/claudius/skills/setup-typed-eslint-monorepo/instructions.md
@@ -3,26 +3,66 @@
 Set up or normalize typed ESLint for monorepo surfaces where Biome would lose
 important framework, security, or domain-specific checks.
 
-**The argument `$ARGUMENTS` is optional** and may provide a comma-separated list
-of target surfaces such as:
+**The argument `$ARGUMENTS` is optional** and may provide
+`profile=<rails-monorepo|polyglot-oss>` plus a comma-separated list of target
+surfaces such as:
 
 - `web,addon`
 - `apps/web,apps/addon`
 - `apps/web,packages/graphql-types`
+- `profile=polyglot-oss apps/web,packages/graphql-types`
 
 If `$ARGUMENTS` is omitted, inspect the repository and infer the candidate
-surfaces.
+surfaces and profile. Use `rails-monorepo` only when the repository clearly has
+a Rails API plus frontend or package surfaces under a shared root. Use
+`polyglot-oss` for general-purpose monorepos that do not fit the Rails profile.
+If the profile remains ambiguous, default the profile reference to
+`polyglot-oss` and report that assumption.
 
 ## References
 
-Read these before editing:
+Read the quality-profile reference that matches the selected profile before
+editing:
 
 - [../setup-quality-profile/references/rails-monorepo.md](../setup-quality-profile/references/rails-monorepo.md)
+- [../setup-quality-profile/references/polyglot-oss.md](../setup-quality-profile/references/polyglot-oss.md)
+
+Do not read or apply the `rails-monorepo` profile when this skill is invoked
+from `polyglot-oss` or when the repository lacks a Rails API surface.
+
+Then read these local references:
+
 - [references/surface-selection.md](references/surface-selection.md)
 - [references/rule-patterns.md](references/rule-patterns.md)
 
-Use the profile reference for naming and CI policy. Use the local references for
-ESLint-vs-Biome selection and surface-specific rule patterns.
+Use the selected profile reference for naming and CI policy. Use the local
+references for ESLint-vs-Biome selection and surface-specific rule patterns.
+
+## Existing Configuration Policy
+
+Before changing an existing repository file, inspect the current content and ask the user to confirm the proposed change. This applies even when the change is additive, such as merging config keys, appending CI steps, adding package scripts, normalizing workflow names, or updating tool versions.
+
+Do not ask when creating a missing file from this skill's template or when the user explicitly requested applying all changes without confirmation. Preserve project-specific settings and avoid replacing entire files unless the user approves that replacement.
+
+When an existing file is involved, present a concise change plan before editing:
+
+- `file`: target path
+- `current_state`: what exists and whether this skill owns it
+- `operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`
+- `proposed_delta`: exact setting, block, command, or path change to add or modify
+- `risk`: compatibility, policy, or behavior risk
+- `question`: the approval needed from the user
+
+Default to `skip` or `merge`. Use `replace` only when the user explicitly
+approves replacing that file.
+
+If the user explicitly requested applying all changes without confirmation, do
+not wait for approval after presenting the plan. Still follow the plan, preserve
+project-specific settings, and do not use `replace` unless the user explicitly
+allowed replacement.
+
+Otherwise, if multiple existing files are affected, batch them in one plan and
+wait for approval before editing any of them.
 
 ## Steps
 

--- a/config/claudius/skills/setup-typed-eslint-monorepo/skill.yaml
+++ b/config/claudius/skills/setup-typed-eslint-monorepo/skill.yaml
@@ -9,4 +9,4 @@ targets:
     invocation: manual
     argument-hint: '[optional: "web,addon,packages/foo"]'
   codex:
-    invocation: manual
+    allow-implicit-invocation: false

--- a/config/claudius/skills/suggest-commit/instructions.md
+++ b/config/claudius/skills/suggest-commit/instructions.md
@@ -1,16 +1,20 @@
 # Git Commit Message Generator
 
-This command analyzes your staged changes and suggests appropriate commit messages following the Conventional Commits specification.
+Analyze staged changes and suggest appropriate commit messages following the
+Conventional Commits specification.
 
 ## Prerequisites
 
-Before using this command:
-1. Ensure you have staged changes: `git add <files>`
-2. Review staged changes: `git diff --cached`
+Before suggesting messages:
+
+1. Run `git diff --cached --stat`.
+2. Run `git diff --cached`.
+3. If there are no staged changes, tell the user to stage changes first.
 
 ## Analysis Process
 
-I will analyze:
+Analyze:
+
 - **File types and paths** to determine commit type and scope
 - **Change patterns** to identify the nature of modifications
 - **Project conventions** from `.commitlintrc`, `.gitmessage`, or commit hooks
@@ -45,19 +49,8 @@ Brief description in imperative mood (e.g., "add OAuth support" not "added OAuth
 
 ## Usage Instructions
 
-1. **Stage your changes**:
-   ```bash
-   git add <files>
-   ```
-
-2. **Run this command** to get commit message suggestions
-
-3. **Choose or modify** a suggested message
-
-4. **Commit** with:
-   ```bash
-   git commit -m "<chosen message>"
-   ```
+Generate 2-4 candidate messages from the staged diff. Do not commit unless the
+user explicitly asks you to commit.
 
 ## Example Output
 
@@ -90,7 +83,3 @@ If your change breaks backward compatibility, add `!` after type:
 ```
 feat!: remove deprecated API endpoints
 ```
-
-## Ready to Analyze
-
-Please share the output of `git diff --cached --stat` and I'll suggest appropriate commit messages based on your staged changes.

--- a/flake.nix
+++ b/flake.nix
@@ -333,6 +333,9 @@
             statix
             shfmt
             shellcheck
+            nodejs
+            biome
+            stylelint
             python3
             (python3.withPackages pythonLintPackages)
             act
@@ -430,7 +433,7 @@
             claudius-skill-guardrails = {
               enable = true;
               name = "claudius-skill-guardrails";
-              entry = "${pkgs.python3}/bin/python3 scripts/test-claudius-skills.py";
+              entry = "${pkgs.bash}/bin/bash -c 'CLAUDIUS_BIN=${lib.getExe' pkgs.claudius "claudius"} ${pkgs.python3}/bin/python3 scripts/test-claudius-skills.py'";
               language = "system";
               pass_filenames = false;
               files = "^config/claudius/skills/|^scripts/test-claudius-skills\\.py$";

--- a/scripts/test-claudius-skills.py
+++ b/scripts/test-claudius-skills.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 """Regression checks for Claudius skill guardrail invariants."""
+# ruff: noqa: PLR0915, S404
 
 from __future__ import annotations
 
+import json
+import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -24,9 +30,32 @@ def check_not_contains(errors: list[str], relative_path: str, needle: str) -> No
         errors.append(f"{relative_path}: forbidden text is present: {needle!r}")
 
 
+def check_contains_normalized(
+    errors: list[str],
+    relative_path: str,
+    needle: str,
+) -> None:
+    haystack = " ".join(read(relative_path).split())
+    normalized_needle = " ".join(needle.split())
+    if normalized_needle not in haystack:
+        errors.append(f"{relative_path}: missing expected text: {needle!r}")
+
+
 def check_not_regex(errors: list[str], relative_path: str, pattern: str) -> None:
     if re.search(pattern, read(relative_path), flags=re.MULTILINE):
         errors.append(f"{relative_path}: forbidden pattern matched: {pattern}")
+
+
+def check_max_line_length(
+    errors: list[str],
+    relative_path: str,
+    max_length: int,
+) -> None:
+    for line_number, line in enumerate(read(relative_path).splitlines(), start=1):
+        if len(line) > max_length:
+            errors.append(
+                f"{relative_path}:{line_number}: line exceeds {max_length} chars",
+            )
 
 
 def check_uses_are_sha_pinned(errors: list[str], relative_path: str) -> None:
@@ -59,6 +88,9 @@ def check_ci_skill(errors: list[str]) -> None:
     check_contains(errors, ci_instructions, "`tflint` | `nix develop -c tflint --init`")
     check_contains(errors, ci_instructions, "Do not skip hooks in CI by default.")
     check_contains(errors, ci_instructions, "`pre-commit-check.enabledPackages`")
+    check_contains(errors, ci_instructions, "Do not replace the")
+    check_contains(errors, ci_instructions, "workflow wholesale")
+    check_contains(errors, ci_instructions, "merge/update it in place")
     check_not_contains(errors, ci_instructions, "nix run nixpkgs#tflint -- --init")
     check_not_contains(
         errors,
@@ -78,9 +110,15 @@ def check_tofu_skill(errors: list[str]) -> None:
     check_contains(errors, tofu_hook, "(^|/)\\\\.tofu-root-modules$")
     check_contains(errors, tofu_hook, "init -backend=false -lockfile=readonly")
     check_contains(errors, tofu_hook, "pass_filenames = false")
+    check_contains(errors, tofu_hook, "tofu fmt -check -diff")
+    check_contains(errors, tofu_hook, "hclfmt-check")
+    check_contains(errors, tofu_hook, 'cmp -s "$file" "$formatted"')
+    check_contains(errors, tofu_hook, 'diff -u "$file" "$formatted"')
     check_contains(errors, tofu_hook, "TOFU_VALIDATE_ROOTS_FILE")
     check_contains(errors, tofu_hook, "TOFU_VALIDATE_ALLOW_NO_LOCKED_ROOTS")
     check_contains(errors, tofu_hook, "missing .terraform.lock.hcl")
+    check_not_contains(errors, tofu_hook, 'entry = "${pkgs.opentofu}/bin/tofu fmt";')
+    check_not_contains(errors, tofu_hook, "${pkgs.hclfmt}/bin/hclfmt -w")
     check_not_contains(errors, tofu_hook, 'dirname "$arg"')
     check_not_contains(
         errors,
@@ -94,6 +132,177 @@ def check_tofu_skill(errors: list[str]) -> None:
     check_not_contains(errors, formatter, 'exec ${pkgs.nixfmt}/bin/nixfmt "$@"')
 
 
+def check_commitlint_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-commitlint/assets/ci-steps.yml.template"
+    instructions = "config/claudius/skills/setup-commitlint/instructions.md"
+    pre_push = (
+        "config/claudius/skills/setup-commitlint/assets/"
+        "commitlint-pre-push.sh.template"
+    )
+
+    check_contains(errors, template, "BEFORE_SHA: ${{ github.event.before }}")
+    check_contains(
+        errors,
+        template,
+        "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
+    )
+    check_contains(errors, template, "BASE_REF: ${{ github.base_ref }}")
+    check_contains(errors, template, "PR_TITLE: ${{ github.event.pull_request.title }}")
+    check_contains(errors, template, 'printf \'%s\\n\' "$PR_TITLE"')
+    check_contains(errors, template, "git rev-parse --is-shallow-repository")
+    check_contains(errors, template, "git fetch --no-tags --prune --unshallow origin")
+    check_contains(errors, template, 'git cat-file -e "$BEFORE_SHA^{commit}"')
+    check_contains(
+        errors,
+        template,
+        'git log -1 --format=%B "$PUSH_SHA" > "$tmp_msg"',
+    )
+    check_contains(
+        errors,
+        template,
+        '"+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"',
+    )
+    check_contains(
+        errors,
+        template,
+        '"+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"',
+    )
+    check_not_contains(errors, template, '--depth=1')
+    check_not_contains(
+        errors,
+        template,
+        'printf \'%s\\n\' "${{ github.event.pull_request.title }}"',
+    )
+    check_contains(errors, instructions, "ask the user before")
+    check_contains(errors, instructions, "replacing or rewriting")
+    check_contains(errors, instructions, "report the proposed scope/rule delta")
+    check_contains(errors, instructions, "ask the user before changing it")
+    check_contains(errors, instructions, "approved, clearly missing baseline rules")
+    check_contains(errors, pre_push, 'remote_name="${1:-origin}"')
+    check_contains(errors, pre_push, '"refs/remotes/${remote_name}/HEAD"')
+    check_contains(errors, pre_push, '"refs/remotes/${remote_name}/main"')
+    check_contains(errors, pre_push, '"refs/remotes/${remote_name}/master"')
+    check_not_contains(errors, pre_push, "refs/remotes/origin/HEAD")
+
+
+def check_tftpl_lint_skill(errors: list[str]) -> None:
+    script = "config/claudius/skills/setup-tftpl-lint/assets/tftpl-validate.sh.template"
+    instructions = "config/claudius/skills/setup-tftpl-lint/instructions.md"
+
+    check_contains(errors, script, "hcl_string()")
+    check_contains(errors, script, 'file_expr="$(hcl_string "${file}")"')
+    check_contains(errors, script, 'vars_expr="$(hcl_string "${vars_file}")"')
+    check_contains(errors, script, '"${engine}" -chdir="${console_dir}" console')
+    check_contains(errors, script, 'console >/dev/null <<TFTPL_EOF')
+    check_contains(errors, script, "tftpl-validate: failed to render")
+    check_contains(
+        errors,
+        script,
+        "templatefile(${file_expr}, jsondecode(file(${vars_expr})))",
+    )
+    check_not_contains(errors, script, '"${engine}" console -chdir=')
+    check_not_contains(
+        errors,
+        script,
+        'templatefile("${file}", jsondecode(file("${vars_file}")))',
+    )
+    check_contains(errors, instructions, "discard rendered template stdout")
+    check_contains(errors, instructions, "Do NOT print")
+
+
+def check_biome_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-biome/assets/biome.json.template"
+    instructions = "config/claudius/skills/setup-biome/instructions.md"
+
+    try:
+        config = json.loads(read(template))
+    except json.JSONDecodeError as error:
+        errors.append(f"{template}: invalid JSON template: {error}")
+        return
+    check_max_line_length(errors, template, 100)
+
+    assist_actions = (
+        config.get("assist", {})
+        .get("actions", {})
+        .get("source", {})
+    )
+    if assist_actions.get("organizeImports") != "on":
+        errors.append(
+            f"{template}: assist.actions.source.organizeImports must be \"on\"",
+        )
+    if "organizeImports" in config:
+        errors.append(f"{template}: top-level organizeImports is invalid for Biome 2")
+
+    rules = config.get("linter", {}).get("rules", {})
+    correctness = rules.get("correctness", {})
+    style = rules.get("style", {})
+    if "useArrayLiterals" in correctness:
+        errors.append(f"{template}: useArrayLiterals belongs under style rules")
+    if style.get("useArrayLiterals") != "error":
+        errors.append(f"{template}: style.useArrayLiterals must be \"error\"")
+
+    overrides = config.get("overrides", [])
+    if not any("includes" in override for override in overrides):
+        errors.append(f"{template}: Biome overrides must use includes")
+    errors.extend(
+        f"{template}: Biome overrides must not use include"
+        for override in overrides
+        if "include" in override
+    )
+
+    check_contains(
+        errors,
+        instructions,
+        "`assist.actions.source.organizeImports`",
+    )
+    check_contains(errors, instructions, "The template enables `vcs.useIgnoreFile`")
+    check_contains(errors, instructions, "If `.gitignore` is missing")
+    check_contains(errors, instructions, "create an empty `.gitignore`")
+    check_contains(errors, instructions, "requires the file to exist")
+    check_not_contains(errors, instructions, "organizeImports.enabled")
+
+
+def check_lean_lint_skill(errors: list[str]) -> None:
+    script = "config/claudius/skills/setup-lean-lint/assets/lean-lint-check.sh.template"
+    instructions = "config/claudius/skills/setup-lean-lint/instructions.md"
+    skill = "config/claudius/skills/setup-lean-lint/skill.yaml"
+    profile = "config/claudius/skills/setup-quality-profile/references/polyglot-oss.md"
+
+    check_contains(errors, script, "lake build")
+    check_contains(errors, script, "lake lint")
+    check_contains(errors, script, "set +e")
+    check_contains(errors, script, "lint_status=$?")
+    check_contains(errors, script, "no lint driver configured")
+    check_contains(errors, script, "LEAN_LINT_REQUIRE_DRIVER")
+    check_not_contains(errors, script, "lake lint --clippy")
+    check_not_contains(errors, script, "lake lint --lint-all")
+    check_not_contains(errors, script, "LEAN_LINT_SCOPE")
+
+    check_contains(errors, instructions, "Lake does not provide a universal")
+    check_contains(errors, instructions, "`--clippy` or `--lint-all`")
+    check_contains(errors, instructions, "`LEAN_LINT_REQUIRE_DRIVER=1`")
+    check_contains(errors, skill, "Lake lint-driver checks")
+    check_contains(
+        errors,
+        profile,
+        "`lake lint` when a project lint driver is configured",
+    )
+    check_not_contains(errors, profile, "lake lint --clippy")
+
+
+def check_just_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-just/assets/justfile.template"
+    instructions = "config/claudius/skills/setup-just/instructions.md"
+
+    check_contains(errors, template, "set positional-arguments")
+    check_contains(errors, template, "set export")
+    check_contains(errors, template, "{{ project_name }}")
+    check_not_contains(errors, template, "set positional-arguments := true")
+    check_not_contains(errors, template, "set export := true")
+    check_not_contains(errors, template, "{{project_name}}")
+    check_contains(errors, instructions, "just --fmt --check --unstable")
+
+
 def check_profile_policy(errors: list[str]) -> None:
     tofu_profile = (
         "config/claudius/skills/setup-quality-profile/references/tofu-infra.md"
@@ -102,6 +311,19 @@ def check_profile_policy(errors: list[str]) -> None:
     check_contains(errors, tofu_profile, "Do not skip")
     check_contains(errors, tofu_profile, "Pin GitHub Actions by full commit SHA")
     check_contains(errors, tofu_profile, "Separate \"update deployment manifest\"")
+
+    polyglot_profile = (
+        "config/claudius/skills/setup-quality-profile/references/polyglot-oss.md"
+    )
+    check_contains(errors, polyglot_profile, "`ts-typecheck`")
+    check_contains(errors, polyglot_profile, "`ruff-check`")
+    check_contains(errors, polyglot_profile, "`mypy-check`")
+    check_contains(errors, polyglot_profile, "`tsc-noEmit`")
+    check_contains(
+        errors,
+        polyglot_profile,
+        "do not rename existing component hook IDs",
+    )
 
     guardrails = "config/claudius/skills/setup-github-guardrails/instructions.md"
     check_contains(errors, guardrails, "full commit SHA")
@@ -122,6 +344,10 @@ def check_profile_policy(errors: list[str]) -> None:
         tofu_project,
         "GitHub Actions left on mutable tag references",
     )
+
+    quality_profile = "config/claudius/skills/setup-quality-profile/instructions.md"
+    check_contains(errors, quality_profile, "profile=rails-monorepo")
+    check_contains(errors, quality_profile, "profile=polyglot-oss")
 
 
 def check_pandacss_skill(errors: list[str]) -> None:
@@ -148,6 +374,15 @@ def check_pandacss_skill(errors: list[str]) -> None:
     check_contains(errors, instructions, "`pkgs.nodejs`")
     check_contains(errors, instructions, "node scripts/check-pandacss-practices.mjs")
     check_contains(errors, instructions, "Do not rely on Panda extraction")
+    check_contains_normalized(errors, instructions, "report the proposed config delta")
+    for needle in [
+        "If `panda.config.ts` already exists",
+        "Merge only missing compatible",
+        "If the root CSS file already exists",
+        "report the proposed Panda",
+        "ask the user before adding or changing imports",
+    ]:
+        check_contains(errors, instructions, needle)
     check_contains(errors, checker, "strictTokens")
     check_contains(errors, checker, "inline style=")
     check_contains(errors, checker, "raw color")
@@ -160,13 +395,724 @@ def check_pandacss_skill(errors: list[str]) -> None:
     check_contains(errors, precommit_hook, "package\\.json")
 
 
+def check_file_hygiene_skill(errors: list[str]) -> None:
+    hooks = "config/claudius/skills/setup-file-hygiene/assets/hooks.nix.template"
+    instructions = "config/claudius/skills/setup-file-hygiene/instructions.md"
+
+    check_contains(errors, hooks, "final-newline-check")
+    check_contains(errors, hooks, "trailing-whitespace-check")
+    check_contains(errors, hooks, "git ls-files -z")
+    check_contains(errors, hooks, "grep -Iq")
+    check_contains(errors, hooks, "last_byte=")
+    check_contains(errors, hooks, "[[:blank:]]$")
+    check_contains(errors, hooks, "builtins.pathExists ./.editorconfig")
+    check_contains(errors, hooks, 'args = [ "--fix=no" ];')
+    check_not_contains(errors, hooks, "editorconfig-checker.enable = true")
+    check_not_contains(errors, hooks, "end-of-file-fixer.enable = true")
+    check_not_contains(errors, hooks, "trim-trailing-whitespace.enable = true")
+    check_not_contains(errors, hooks, "mixed-line-endings.enable = true")
+    check_contains(errors, hooks, "builtins.pathExists ./.markdownlint.json")
+    check_contains(
+        errors,
+        hooks,
+        "builtins.fromJSON (builtins.readFile ./.markdownlint.json)",
+    )
+    check_not_contains(
+        errors,
+        hooks,
+        (
+            "settings.configuration = builtins.fromJSON "
+            "(builtins.readFile ./.markdownlint.json);"
+        ),
+    )
+    check_contains(errors, hooks, "builtins.pathExists ./.typos.toml")
+    check_contains(errors, hooks, '{ configPath = ".typos.toml"; }')
+    check_contains(errors, hooks, "{ config = { }; }")
+    check_not_contains(errors, hooks, 'settings.configPath = ".typos.toml";')
+    check_contains(errors, instructions, "defaults are used when missing")
+    check_contains(
+        errors,
+        instructions,
+        "editorconfig-checker is disabled when missing",
+    )
+    check_contains(errors, instructions, "configPath` only when the file exists")
+    check_contains(errors, instructions, "tracked non-empty text files")
+    check_contains(errors, instructions, "Keep file hygiene hooks check-only")
+    check_contains(errors, instructions, "explicitly accepts auto-fix behavior")
+    check_contains(errors, instructions, "configured with `--fix=no`")
+
+
+def check_rubocop_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-rubocop/assets/rubocop.yml.template"
+    instructions = "config/claudius/skills/setup-rubocop/instructions.md"
+
+    if "__RUBY_VERSION__" in read(template):
+        check_contains(errors, instructions, "__RUBY_VERSION__")
+        check_contains(errors, instructions, ".ruby-version")
+        check_contains(errors, instructions, ".tool-versions")
+        check_contains(errors, instructions, "mise.toml")
+        check_contains(errors, instructions, "Gemfile")
+        check_contains(errors, instructions, "Do not leave the `__RUBY_VERSION__`")
+    check_contains(errors, instructions, "If `.rubocop.yml` already exists")
+    check_contains(errors, instructions, "ask the user before changing")
+    check_contains(errors, instructions, "Do NOT duplicate plugin")
+    check_contains(errors, instructions, "existing plugin order")
+
+
+def check_rails_ci_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-rails-ci/assets/ci.yml.template"
+    instructions = "config/claudius/skills/setup-rails-ci/instructions.md"
+
+    check_uses_are_sha_pinned(errors, template)
+    check_contains(errors, template, "contents: read")
+    check_contains(errors, template, '      - "**"')
+    check_contains(errors, template, "  test:")
+    check_contains(errors, template, "name: Test")
+    check_contains(errors, template, "ruby-version: __RUBY_VERSION__")
+    check_not_contains(errors, template, "branches: [ main ]")
+    check_not_contains(errors, template, "ruby-version: .ruby-version")
+    check_not_regex(errors, template, r"uses:\s+[^@\s]+@v\d+")
+    check_contains(errors, instructions, "push CI for all branches")
+    check_contains(errors, instructions, "three jobs")
+    check_not_contains(errors, instructions, "two jobs")
+    check_contains(errors, instructions, "__RUBY_VERSION__")
+    check_contains(errors, instructions, ".tool-versions")
+    check_contains(errors, instructions, "mise.toml")
+    check_contains(errors, instructions, "bundle exec rspec")
+    check_contains(errors, instructions, "bin/rails test")
+    check_contains(errors, instructions, "bundle exec brakeman --no-pager")
+    check_contains(errors, instructions, "bundle exec rubocop -f github")
+    check_contains(errors, instructions, "If `simplecov` is present")
+    check_contains(errors, instructions, "permissions: contents: read")
+    check_contains(errors, instructions, "full commit SHA")
+    check_contains(errors, instructions, "Do not switch these actions back")
+    check_contains(errors, instructions, "Do not replace the workflow")
+    check_contains(errors, instructions, "wholesale")
+    check_contains(errors, instructions, "merge/update it in place")
+
+
+def check_rails_testing_skill(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-rails-testing/instructions.md"
+
+    check_contains(errors, instructions, "rspec-rails")
+    check_contains(errors, instructions, "spec/spec_helper.rb")
+    check_contains(errors, instructions, "spec/rails_helper.rb")
+    check_contains(errors, instructions, "before any other requires")
+    check_contains(errors, instructions, "before application boot")
+    check_contains(errors, instructions, "SimpleCov is already configured")
+    check_contains(errors, instructions, "do not add a duplicate block")
+    check_contains(errors, instructions, "If `.gitignore` exists")
+    check_contains(errors, instructions, "ask the user before appending")
+    check_not_contains(
+        errors,
+        instructions,
+        "If not already present, add `coverage/` to `.gitignore`.",
+    )
+
+
+def check_repository_baseline_skill(errors: list[str]) -> None:
+    instructions = (
+        "config/claudius/skills/setup-repository-baseline/instructions.md"
+    )
+
+    check_contains(errors, instructions, "__REPOSITORY_NAME__")
+    check_contains(errors, instructions, "__DEFAULT_BRANCH__")
+    check_contains(errors, instructions, "__PRIMARY_OWNER__")
+    check_contains(errors, instructions, "__SECURITY_CONTACT__")
+    check_contains(errors, instructions, "Do not leave any")
+    for needle in [
+        "report missing baseline policy items",
+        "report missing baseline security policy items",
+        "report whether `Unreleased`",
+        "report missing release-process items",
+        "report missing PR-description fields",
+        "inspect it and ask the user before changing it",
+    ]:
+        check_contains(errors, instructions, needle)
+
+
+def check_i18n_lint_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-i18n-lint/assets/i18n-tasks.yml.template"
+    instructions = "config/claudius/skills/setup-i18n-lint/instructions.md"
+
+    check_contains(errors, template, "base_locale: __BASE_LOCALE__")
+    check_contains(errors, template, "locales: __LOCALES__")
+    check_not_contains(errors, template, "base_locale: ja")
+    check_not_contains(errors, template, "locales: [ja, en]")
+    check_contains(errors, instructions, "__BASE_LOCALE__")
+    check_contains(errors, instructions, "__LOCALES__")
+    check_contains(errors, instructions, "Do not assume `ja`")
+    check_contains_normalized(
+        errors,
+        instructions,
+        "Do not append duplicate rule blocks",
+    )
+    check_contains(errors, instructions, "If `config/i18n-tasks.yml` already exists")
+    check_contains(errors, instructions, "If `.github/workflows/ci.yml` exists")
+    check_contains(errors, instructions, "ask the user before")
+    check_contains(errors, instructions, "Do NOT duplicate")
+    check_contains(errors, instructions, "i18n-tasks missing")
+    check_contains_normalized(errors, instructions, "Preserve the existing workflow")
+
+
+def check_stylelint_skill(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-stylelint/instructions.md"
+    template = "config/claudius/skills/setup-stylelint/assets/stylelintrc.yml.template"
+
+    check_contains(errors, instructions, "Do not switch package managers")
+    check_contains(errors, instructions, "npm run lint:css")
+    check_contains(errors, instructions, "pnpm lint:css")
+    check_contains(errors, instructions, "yarn lint:css")
+    check_contains(errors, instructions, "bun run lint:css")
+    check_contains(errors, instructions, "If a Stylelint config already exists")
+    check_contains(errors, instructions, "Do not overwrite existing scripts")
+    check_contains(errors, instructions, "If `.github/workflows/ci.yml` exists")
+    check_contains(errors, instructions, "ask the user before")
+    check_contains(errors, instructions, "Do NOT duplicate")
+    check_contains_normalized(errors, instructions, "Preserve the existing workflow")
+    check_not_contains(errors, instructions, "run: yarn lint:css")
+    check_not_contains(errors, instructions, "Run the following to install")
+    check_contains(errors, template, 'ignoreValues: ["currentColor"')
+    check_contains(errors, template, "expandShorthand: true")
+    check_contains(errors, template, "scss/load-no-partial-leading-underscore")
+    check_not_contains(errors, template, "expandShorthandProperties")
+    check_not_contains(errors, template, "scss/at-import-no-partial-leading-underscore")
+
+
+def check_rails_db_safety_skill(errors: list[str]) -> None:
+    template = (
+        "config/claudius/skills/setup-rails-db-safety/assets/"
+        "strong_migrations.rb.template"
+    )
+    instructions = "config/claudius/skills/setup-rails-db-safety/instructions.md"
+
+    if "__PG_VERSION__" in read(template):
+        check_contains(errors, instructions, "__PG_VERSION__")
+        check_contains(errors, instructions, "PostgreSQL major version")
+        check_contains(errors, instructions, "config/database.yml")
+        check_contains(errors, instructions, "Docker Compose")
+        check_contains(errors, instructions, "Do not leave the `__PG_VERSION__`")
+        check_contains(errors, instructions, "If the initializer already exists")
+        check_contains(
+            errors,
+            instructions,
+            "If `.database_consistency.yml` already exists",
+        )
+
+
+def check_tofu_project_skill(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-tofu-project/instructions.md"
+    content = read(instructions)
+    after_completion = content.split("## After Completion", 1)[1]
+    required = after_completion.split("Also mention these optional", 1)[0]
+
+    check_contains(errors, instructions, "required config files")
+    check_contains(errors, instructions, "optional override files")
+    check_contains(errors, instructions, "markdownlint uses defaults")
+    check_contains(errors, instructions, "typos uses defaults")
+    check_contains(errors, instructions, "without explicit scopes")
+    check_not_contains(errors, instructions, "ask the user for the list of scopes")
+    if ".markdownlint.json" in required:
+        errors.append(
+            f"{instructions}: .markdownlint.json is listed as a required config",
+        )
+    if ".typos.toml" in required:
+        errors.append(f"{instructions}: .typos.toml is listed as a required config")
+
+
+def check_c_lint_skill(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-c-lint/instructions.md"
+    hooks = "config/claudius/skills/setup-c-lint/assets/hooks.nix.template"
+    precommit = (
+        "config/claudius/skills/setup-c-lint/assets/"
+        "pre-commit-hooks.yaml.template"
+    )
+    script = (
+        "config/claudius/skills/setup-c-lint/assets/"
+        "clang-tidy-check.sh.template"
+    )
+
+    check_contains(errors, hooks, 'files = "\\\\.(c|cc|cpp|cxx|h|hh|hpp|hxx)$";')
+    check_contains(errors, hooks, "pass_filenames = true")
+    check_contains(errors, precommit, "\\.(c|cc|cpp|cxx|h|hh|hpp|hxx)$")
+    check_contains(errors, script, "git ls-files '*.c' '*.cc' '*.cpp' '*.cxx'")
+    check_contains(errors, script, 'exec clang-tidy -p "${build_dir}" "${files[@]}"')
+    check_not_contains(errors, script, "No input files provided to clang-tidy.")
+    check_contains(errors, instructions, "If `.clang-format` already exists")
+    check_contains(errors, instructions, "If `.clang-tidy` already exists")
+    check_contains(errors, instructions, "If the script already exists")
+
+
+def check_just_lint_skill(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-just-lint/instructions.md"
+    hooks = "config/claudius/skills/setup-just-lint/assets/hooks.nix.template"
+
+    check_contains(errors, hooks, 'mkHook "just-evaluate" "just --evaluate"')
+    check_not_contains(errors, hooks, "just --evaluate --justfile")
+    check_contains(errors, instructions, "ask the user before changing")
+    check_contains(
+        errors,
+        instructions,
+        "Do NOT remove or modify any existing hooks without explicit user approval.",
+    )
+    check_not_contains(
+        errors,
+        instructions,
+        "remove it. This repository has been abandoned since January 2024",
+    )
+
+
+def check_google_workspace_iac_skill(errors: list[str]) -> None:
+    skill = "config/claudius/skills/setup-google-workspace-iac/skill.yaml"
+    instructions = "config/claudius/skills/setup-google-workspace-iac/instructions.md"
+
+    check_contains(errors, skill, "name: setup-google-workspace-iac")
+    check_contains(errors, skill, "Google Workspace")
+    check_contains(errors, skill, "Cloud Identity")
+    check_contains(errors, skill, "allow-implicit-invocation: false")
+
+    for needle in [
+        "Separate identity governance from Google Cloud project infrastructure.",
+        "Never manage passwords, recovery channels, backup codes, or one-time secrets",
+        "authoritative",
+        "additive",
+        "catalog-only",
+        "Do not convert a group to authoritative management unless the user approves",
+        "domain-wide delegation scopes minimal",
+        "Treat Google Workspace exports",
+        "Do not commit raw admin exports",
+        "`data_sensitivity`",
+        "`commit_allowed`",
+        "Store only sanitized reproducible command output in `results/`",
+        (
+            "identity/access artifacts committed, sanitized, or kept outside "
+            "the repository"
+        ),
+        "AWS IAM Identity Center",
+        "Do not let a Google Workspace state mutate AWS account assignments directly.",
+        "Do not run an apply until the user has reviewed",
+    ]:
+        check_contains(errors, instructions, needle)
+
+
+def check_multicloud_iac_structure_skill(errors: list[str]) -> None:
+    instructions = (
+        "config/claudius/skills/setup-multicloud-iac-structure/instructions.md"
+    )
+
+    check_contains(
+        errors,
+        instructions,
+        "Determine the target clouds from `$ARGUMENTS`",
+    )
+    check_contains(errors, instructions, "clouds outside the confirmed scope")
+    check_contains(errors, instructions, "Create only the selected `stacks/<cloud>`")
+    check_contains(errors, instructions, "only for selected clouds")
+    check_contains(errors, instructions, "only for governed regions")
+    check_not_contains(
+        errors,
+        instructions,
+        "Create `stacks/aws`, `stacks/azure`, `stacks/gcp`",
+    )
+
+
+def check_typed_eslint_profile_selection(errors: list[str]) -> None:
+    instructions = (
+        "config/claudius/skills/setup-typed-eslint-monorepo/instructions.md"
+    )
+
+    check_contains(errors, instructions, "profile=<rails-monorepo|polyglot-oss>")
+    check_contains(errors, instructions, "profile=polyglot-oss")
+    check_contains(errors, instructions, "Read the quality-profile reference")
+    check_contains(
+        errors,
+        instructions,
+        "Do not read or apply the `rails-monorepo` profile",
+    )
+    check_contains(errors, instructions, "Use the selected profile reference")
+
+
+def check_shell_template_formatting(errors: list[str]) -> None:
+    shfmt = shutil.which("shfmt")
+    if shfmt is None:
+        errors.append("shfmt is required to validate shell skill templates")
+        return
+
+    shell_templates = sorted(
+        str(path.relative_to(ROOT))
+        for path in (ROOT / "config/claudius/skills").glob("*/assets/*.sh.template")
+    )
+    if not shell_templates:
+        return
+
+    result = subprocess.run(
+        [shfmt, "-i", "2", "-d", *shell_templates],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        details = (result.stdout + result.stderr).strip()
+        errors.append(f"shell templates are not shfmt-formatted:\n{details}")
+
+
+def check_skill_catalog_inventory(errors: list[str]) -> None:
+    skills_dir = ROOT / "config/claudius/skills"
+    skill_names = {path.name for path in skills_dir.iterdir() if path.is_dir()}
+    docs = [
+        "config/claudius/docs/skills/catalog.yaml",
+        "config/claudius/docs/skills/inventory.yaml",
+    ]
+
+    for relative_path in docs:
+        documented: set[str] = set()
+        in_skills = False
+        for line in read(relative_path).splitlines():
+            if line == "skills:":
+                in_skills = True
+                continue
+            if in_skills and line and not line.startswith(" "):
+                break
+            match = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+            if in_skills and match:
+                documented.add(match.group(1))
+        missing = sorted(skill_names - documented)
+        extra = sorted(documented - skill_names)
+        if missing:
+            errors.append(f"{relative_path}: missing skill entries: {missing}")
+        if extra:
+            errors.append(f"{relative_path}: stale skill entries: {extra}")
+
+
+def check_setup_skill_safety_policy(errors: list[str]) -> None:
+    for skill_dir in sorted((ROOT / "config/claudius/skills").glob("setup-*")):
+        instructions = skill_dir / "instructions.md"
+        skill_yaml = skill_dir / "skill.yaml"
+        instructions_path = str(instructions.relative_to(ROOT))
+        skill_yaml_path = str(skill_yaml.relative_to(ROOT))
+
+        check_contains(errors, instructions_path, "## Existing Configuration Policy")
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "Before changing an existing repository file",
+        )
+        check_contains_normalized(errors, instructions_path, "ask the user to confirm")
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "even when the change is additive",
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            (
+                "When an existing file is involved, present a concise change "
+                "plan before editing"
+            ),
+        )
+        check_contains(errors, instructions_path, "`file`: target path")
+        check_contains(errors, instructions_path, "`current_state`:")
+        check_contains(
+            errors,
+            instructions_path,
+            "`operation`: `skip`, `merge`, `update`, `replace`, or `create-adjacent`",
+        )
+        check_contains(errors, instructions_path, "`proposed_delta`:")
+        check_contains(errors, instructions_path, "`risk`:")
+        check_contains(errors, instructions_path, "`question`:")
+        check_contains(errors, instructions_path, "Default to `skip` or `merge`")
+        check_contains(
+            errors,
+            instructions_path,
+            "Use `replace` only when the user explicitly",
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            (
+                "If the user explicitly requested applying all changes without "
+                "confirmation"
+            ),
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "do not wait for approval after presenting the plan",
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "Still follow the plan, preserve",
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "do not use `replace` unless the user explicitly",
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "Otherwise, if multiple existing files are affected",
+        )
+        check_contains(
+            errors,
+            instructions_path,
+            "batch",
+        )
+        check_contains_normalized(
+            errors,
+            instructions_path,
+            "wait for approval before editing any of them",
+        )
+        check_contains(errors, skill_yaml_path, "allow-implicit-invocation: false")
+        check_not_contains(errors, skill_yaml_path, "  codex:\n    invocation: manual")
+        check_not_contains(errors, instructions_path, "\\x27")
+        check_not_contains(
+            errors,
+            instructions_path,
+            "there is no valid reason to deviate",
+        )
+        check_not_contains(
+            errors,
+            instructions_path,
+            "replace** them with the values below",
+        )
+
+
+def check_codex_rendered_setup_skill_policy(errors: list[str]) -> None:
+    claudius = os.environ.get("CLAUDIUS_BIN", "claudius")
+    with tempfile.TemporaryDirectory(prefix="claudius-codex-render-") as temp_dir:
+        env = os.environ.copy()
+        env["XDG_CONFIG_HOME"] = str(ROOT / "config")
+        result = subprocess.run(
+            [
+                claudius,
+                "skills",
+                "render",
+                "--agent",
+                "codex",
+                "--output",
+                temp_dir,
+                "--prune",
+            ],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            errors.append(
+                "codex skill render failed: "
+                f"{result.stderr.strip() or result.stdout.strip()}",
+            )
+            return
+
+        for skill_dir in sorted((ROOT / "config/claudius/skills").glob("setup-*")):
+            relative_policy_path = Path(skill_dir.name) / "agents/openai.yaml"
+            policy_path = Path(temp_dir) / relative_policy_path
+            if not policy_path.exists():
+                errors.append(
+                    (
+                        "codex render: missing "
+                        f"{relative_policy_path} for manual setup skill"
+                    ),
+                )
+                continue
+            policy = policy_path.read_text(encoding="utf-8")
+            if "allow_implicit_invocation: false" not in policy:
+                errors.append(
+                    (
+                        "codex render: "
+                        f"{relative_policy_path} must disable implicit invocation"
+                    ),
+                )
+
+
+def check_git_hooks_skill(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-git-hooks/instructions.md"
+
+    check_contains_normalized(errors, instructions, "report the proposed rename")
+    check_contains_normalized(errors, instructions, "ask the user before changing it")
+    check_contains(errors, instructions, "update all references consistently")
+
+
+def check_ruby_lint_skill(errors: list[str]) -> None:
+    template = "config/claudius/skills/setup-ruby-lint/assets/rubocop.yml.template"
+    instructions = "config/claudius/skills/setup-ruby-lint/instructions.md"
+
+    check_contains(errors, template, "  # __OPTIONAL_PLUGINS__")
+    check_not_contains(errors, template, "\n__OPTIONAL_PLUGINS__")
+    check_contains(errors, instructions, "the full `  # __OPTIONAL_PLUGINS__` line")
+    check_contains(errors, instructions, "If no optional surface is detected")
+    check_contains(errors, instructions, "remove the placeholder line entirely")
+    check_contains(errors, instructions, "Do not leave `__OPTIONAL_PLUGINS__`")
+
+
+def check_command_style_skills(errors: list[str]) -> None:
+    gemini_skill = "config/claudius/skills/gemini-web-search/skill.yaml"
+    gemini_instructions = "config/claudius/skills/gemini-web-search/instructions.md"
+    check_contains(errors, gemini_skill, "explicitly asks")
+    check_contains(errors, gemini_instructions, "only when the user explicitly asks")
+    check_contains(errors, gemini_instructions, "Do not claim it is more accurate")
+    check_not_contains(errors, gemini_skill, "instead of built-in web search")
+    check_not_contains(errors, gemini_instructions, "Ready to Search")
+    check_not_contains(errors, gemini_instructions, "Please provide your search query")
+
+    suggest = "config/claudius/skills/suggest-commit/instructions.md"
+    check_contains(errors, suggest, "git diff --cached --stat")
+    check_contains(errors, suggest, "git diff --cached")
+    check_contains(errors, suggest, "Do not commit unless")
+    check_not_contains(errors, suggest, "Please share the output")
+    check_not_contains(errors, suggest, "Ready to Analyze")
+
+    organize = "config/claudius/skills/organize-context/instructions.md"
+    check_contains(errors, organize, "Target Discovery")
+    check_contains(errors, organize, "config/claudius/rules")
+    check_contains(errors, organize, "selected rules directory")
+    check_contains(errors, organize, "Before changing an existing context document")
+    check_contains(errors, organize, "ask the user to confirm")
+    check_not_contains(errors, organize, "Scan `/rules/` directory")
+    check_not_contains(errors, organize, "All rules in `/rules/`")
+    check_not_contains(errors, organize, "Ready to Organize")
+    check_not_contains(errors, organize, "Please provide:")
+
+
+def check_python_lint_placeholders(errors: list[str]) -> None:
+    instructions = "config/claudius/skills/setup-python-lint/instructions.md"
+
+    check_contains(errors, instructions, "Use unquoted replacement values")
+    check_contains(errors, instructions, "The template already includes TOML quotes")
+    check_contains(
+        errors,
+        instructions,
+        "Inspect `pyproject.toml` for Ruff and mypy sections independently",
+    )
+    check_contains(errors, instructions, "Do not skip")
+    check_contains(
+        errors,
+        instructions,
+        "mypy setup just because Ruff is already configured",
+    )
+    check_contains(errors, instructions, "If `[tool.mypy]` is missing")
+    check_not_contains(errors, instructions, 'e.g. `"py312"`')
+    check_not_contains(errors, instructions, 'e.g. `"3.12"`')
+    check_not_contains(errors, instructions, 'e.g. `"myapp"`')
+    template = (
+        "config/claudius/skills/setup-python-lint/assets/"
+        "pyproject.ruff.toml.template"
+    )
+    check_not_contains(errors, template, "ANN101")
+    check_not_contains(errors, template, "ANN102")
+
+
+def check_existing_file_merge_policy_details(errors: list[str]) -> None:
+    expectations = {
+        "config/claudius/skills/setup-commitlint/instructions.md": [
+            "If the script already exists",
+            "Merge the missing merge-base behavior",
+        ],
+        "config/claudius/skills/setup-erb-lint/instructions.md": [
+            "If `.erb-lint.yml` already exists",
+            "If the initializer already exists",
+            "If `.github/workflows/ci.yml` exists",
+            "ask the user before",
+            "Do NOT duplicate",
+            "Preserve the existing workflow",
+        ],
+        "config/claudius/skills/setup-haskell-lint/instructions.md": [
+            "If the script already exists",
+            "Merge missing strict-check behavior",
+        ],
+        "config/claudius/skills/setup-lean-lint/instructions.md": [
+            "If the script already exists",
+            "Merge missing Lean quality checks",
+        ],
+        "config/claudius/skills/setup-secrets-scan/instructions.md": [
+            "include exactly one `--config .gitleaks.toml`",
+            "ask the user before changing it",
+        ],
+        "config/claudius/skills/setup-sql-lint/instructions.md": [
+            "If `.sqlfluff` already exists",
+            "Do not replace the file wholesale",
+        ],
+        "config/claudius/skills/setup-tftpl-lint/instructions.md": [
+            "If the variables file already exists",
+            "If the script already exists",
+        ],
+        "config/claudius/skills/setup-just/instructions.md": [
+            "or replacing mandatory settings",
+            "before adding the mandatory recipe name as a wrapper",
+        ],
+        "config/claudius/skills/setup-capybara-lint/instructions.md": [
+            "If `.rubocop.yml` exists",
+            "ask the user before changing it",
+            "preserve the current values",
+        ],
+        "config/claudius/skills/setup-nix-ci-lint/instructions.md": [
+            "check whether equivalent commitlint or PR-title",
+            "Do NOT duplicate them",
+            "replacing or rewriting those steps",
+        ],
+        "config/claudius/skills/setup-sorbet/instructions.md": [
+            "If `.rubocop.yml` exists",
+            "ask the user before changing it",
+            "existing plugin order",
+        ],
+        "config/claudius/skills/setup-ruby-lint/instructions.md": [
+            "If `.rubocop.yml` already exists",
+            "ask the user before changing",
+            "Do NOT duplicate plugin",
+            "existing plugin order",
+        ],
+    }
+    for relative_path, needles in expectations.items():
+        for needle in needles:
+            check_contains(errors, relative_path, needle)
+    check_contains_normalized(
+        errors,
+        "config/claudius/skills/setup-capybara-lint/instructions.md",
+        "Do not append duplicate rule blocks",
+    )
+
+
 def main() -> int:
     errors: list[str] = []
 
     check_ci_skill(errors)
     check_tofu_skill(errors)
+    check_commitlint_skill(errors)
+    check_tftpl_lint_skill(errors)
+    check_biome_skill(errors)
+    check_lean_lint_skill(errors)
     check_profile_policy(errors)
     check_pandacss_skill(errors)
+    check_file_hygiene_skill(errors)
+    check_rubocop_skill(errors)
+    check_rails_ci_skill(errors)
+    check_rails_testing_skill(errors)
+    check_repository_baseline_skill(errors)
+    check_i18n_lint_skill(errors)
+    check_stylelint_skill(errors)
+    check_rails_db_safety_skill(errors)
+    check_tofu_project_skill(errors)
+    check_c_lint_skill(errors)
+    check_just_skill(errors)
+    check_just_lint_skill(errors)
+    check_google_workspace_iac_skill(errors)
+    check_multicloud_iac_structure_skill(errors)
+    check_typed_eslint_profile_selection(errors)
+    check_skill_catalog_inventory(errors)
+    check_setup_skill_safety_policy(errors)
+    check_codex_rendered_setup_skill_policy(errors)
+    check_git_hooks_skill(errors)
+    check_ruby_lint_skill(errors)
+    check_command_style_skills(errors)
+    check_python_lint_placeholders(errors)
+    check_existing_file_merge_policy_details(errors)
+    check_shell_template_formatting(errors)
 
     if errors:
         print("Claudius skill guardrail checks failed:", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Harden shared Claudius setup skills with explicit existing-configuration safety policies and safer check-only behavior
- Add a Google Workspace / Cloud Identity IaC skill with identity artifact and credential handling guidance
- Update the skills catalog and inventory for new/refined skill surfaces
- Add regression guardrail checks and devShell tooling for skill validation

## Verification
- python3 -m py_compile scripts/test-claudius-skills.py && python3 scripts/test-claudius-skills.py
- XDG_CONFIG_HOME="$PWD/config" claudius skills validate --debug --strict
- claudius skills render --agent codex --prune
- nix develop .#ci -c biome ci against the generated Biome template
