### PR TITLE
fix(vscode): support musl copilot binary in insiders

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -115,7 +115,7 @@ let
     aarch64-linux = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
     x86_64-darwin = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
     aarch64-darwin = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
-};
+  };
 
   rustyV8Version = "146.4.0";
 

--- a/config/home-manager/programs/vscode/default.nix
+++ b/config/home-manager/programs/vscode/default.nix
@@ -49,8 +49,10 @@ let
       oldAttrs.runtimeDependencies
       ++ [
         pkgs.libsecret
+        pkgs.musl
       ]
     );
+    autoPatchelfIgnoreMissingDeps = lib.optionals pkgs.stdenv.isLinux [ "libc.musl-x86_64.so.1" ];
     urlHandlerDesktopItem = pkgs.makeDesktopItem {
       name = "code-insiders-url-handler";
       desktopName = "Visual Studio Code - Insiders - URL Handler";


### PR DESCRIPTION
## Summary
- add musl to the Linux runtime dependencies for VS Code Insiders
- ignore the musl libc symlink name during auto-patchelf so the bundled Copilot linux-musl binary no longer fails the build

## Verification
- nix run --impure '.#switch'
- git diff --check HEAD~1..HEAD
- commit hooks during git commit
- pre-push hooks during git push