### PR TITLE
fix(ai-tools): stabilize codex updater replacements

### DIFF
--- a/config/home-manager/home/packages/claude-code.nix
+++ b/config/home-manager/home/packages/claude-code.nix
@@ -2,16 +2,16 @@
 
 let
   pname = "claude-code";
-  version = "2.1.146";
+  version = "2.1.158";
 
   sources = {
     aarch64-darwin = {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-${version}.tgz";
-      hash = "sha256-bK3HSIf+bLFHirg5CT9DpPIr2WDHs4r+T4vQzdxf3Gc=";
+      hash = "sha256-uVb8JF3471ZnZ47/sKVLwNQopp8kM1LG+6K7LdhcMO4=";
     };
     x86_64-linux = {
       url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-${version}.tgz";
-      hash = "sha256-NhjIeXeTd8Vk6IALD1QTMAsxWpWSVceYqt/MVhZEYlo=";
+      hash = "sha256-VtDfd+JlvVE35NnIPcZ/u4jSp45qzBOXRn509EAf1L4=";
     };
   };
 

--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -111,13 +111,13 @@ let
   # cargo vendor utility. codex-utils-cargo-bin is only used by test helpers,
   # and tests are disabled for this package, so the stub is sufficient.
   cargoHashes = {
-    x86_64-linux = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
-    aarch64-linux = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
-    x86_64-darwin = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
-    aarch64-darwin = "sha256-7gHqZHViytvGLRH3SHyBgtrR9s/W1itLr6Eekfac1kE=";
+    x86_64-linux = "sha256-951guRubvmbgiMaBGTlTOBunoFGjAEc7+0Wnt06gNFE=";
+    aarch64-linux = "sha256-951guRubvmbgiMaBGTlTOBunoFGjAEc7+0Wnt06gNFE=";
+    x86_64-darwin = "sha256-951guRubvmbgiMaBGTlTOBunoFGjAEc7+0Wnt06gNFE=";
+    aarch64-darwin = "sha256-951guRubvmbgiMaBGTlTOBunoFGjAEc7+0Wnt06gNFE=";
   };
 
-  rustyV8Version = "146.4.0";
+  rustyV8Version = "147.4.0";
 
   rustyV8Targets = {
     x86_64-linux = "x86_64-unknown-linux-gnu";
@@ -127,10 +127,10 @@ let
   };
 
   rustyV8ArchiveHashes = {
-    x86_64-linux = "sha256-5ktNmeSuKTouhGJEqJuAF4uhA4LBP7WRwfppaPUpEVM=";
-    aarch64-linux = "sha256-2/FlsHyBvbBUvARrQ9I+afz3vMGkwbW0d2mDpxBi7Ng=";
-    x86_64-darwin = "sha256-YwzSQPG77NsHFBfcGDh6uBz2fFScHFFaC0/Pnrpke7c=";
-    aarch64-darwin = "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo=";
+    x86_64-linux = "sha256-Cd3vbFEZKv/wVBExoO+cAPgxhdI5HaqxgDgqOr82rJU=";
+    aarch64-linux = "sha256-lMPw/eAFFAT8obaR8opJbXjbgw58+0maBEyxpeOllFU=";
+    x86_64-darwin = "sha256-+ppR8dMhVTSZL0PPar+DlKZ0K+E5N7WfdXXfBTYel+Y=";
+    aarch64-darwin = "sha256-fnR0DD7woOj8DiaKJYYSPpg0D+lDVmjNwSiPrvtzYq4=";
   };
 
   rustyV8Archive = pkgs.fetchurl {
@@ -189,13 +189,13 @@ in
 rustPlatform.buildRustPackage (
   rec {
     pname = "codex-cli";
-    version = "rust-v0.132.0";
+    version = "rust-v0.135.0";
 
     src = pkgs.fetchFromGitHub {
       owner = "openai";
       repo = "codex";
       rev = "${version}";
-      hash = "sha256-T+iPhi0/h6+tIGZy04e8l8xjxUBH/aUQ21pXbunLYxM=";
+      hash = "sha256-7Ak7rpogcN2kNezk7aMdMmkgNyPxH58f6lFdXOd/mgc=";
     };
 
     sourceRoot = "source/codex-rs";

--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -98,13 +98,12 @@ let
 
   opensslPkg = pkgs.openssl;
 
-  rustPlatform =
-    if pkgs.stdenv.isLinux then
-      pkgs.makeRustPlatform {
-        inherit (pkgs.unstable) cargo rustc;
-      }
-    else
-      pkgs.rustPlatform;
+  # Codex tracks recent Rust dependencies closely. Use the unstable Rust
+  # toolchain on every platform so dependency MSRV bumps do not break Darwin
+  # while Linux is still using a newer compiler.
+  rustPlatform = pkgs.makeRustPlatform {
+    inherit (pkgs.unstable) cargo rustc;
+  };
 
   # Replace the upstream runfiles git dependency with a tiny local stub.
   # rules_rust ships examples that use -Z bindeps, which breaks nixpkgs'
@@ -238,15 +237,15 @@ rustPlatform.buildRustPackage (
       EOF
     ''
     + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-      # LLVM 21 / rustc 1.91.1 currently crashes in release optimization passes
-      # for this workspace. Lower Linux release optimization until nixpkgs updates.
+      # LLVM currently crashes in release optimization passes for this
+      # workspace. Lower Linux release optimization until the toolchain settles.
       perl -0pi -e 's/\\[profile\\.release\\]\\n/[profile.release]\\nopt-level = 2\\n/' Cargo.toml
     '';
 
     # Enable unstable features (file_lock)
     RUSTC_BOOTSTRAP = "1";
 
-    # Disable LTO to work around LLVM 21.1.2 + rustc 1.91.1 ICE during LTO codegen.
+    # Disable LTO to work around LLVM ICEs during LTO codegen.
     # The crash occurs in LLVMContextDispose when building with lto=fat.
     # This affects both binary size and runtime performance (5-20% slower).
     # TODO: Re-enable LTO ("fat" or "thin") once nixpkgs updates LLVM/rustc.
@@ -256,7 +255,7 @@ rustPlatform.buildRustPackage (
     # Upstream pins codegen-units=1 for smaller binaries. Keep that on Darwin,
     # where we need to minimize link distance for the large WebRTC static
     # archive. Linux still needs multiple codegen units to avoid an LLVM 21 /
-    # rustc 1.91.1 SIGSEGV while compiling `image`.
+    # rustc SIGSEGV while compiling `image`.
     CARGO_PROFILE_RELEASE_CODEGEN_UNITS = if pkgs.stdenv.isLinux then "16" else "1";
 
     # Show backtrace for build failures

--- a/config/home-manager/home/packages/droid.nix
+++ b/config/home-manager/home/packages/droid.nix
@@ -2,17 +2,17 @@
 
 let
   pname = "droid";
-  version = "0.130.0";
+  version = "0.137.1";
 
   # Platform-specific source URLs and hashes
   sources = {
     aarch64-darwin = {
       url = "https://downloads.factory.ai/factory-cli/releases/${version}/darwin/arm64/droid";
-      hash = "sha256-8SrBtya8t96YlBZ3emfwtn3Y3DaM/dLF6foIceY2cCs=";
+      hash = "sha256-4bMws+bGWDGQnxHSai2petwUl+QeAxutiyxnxzfguLs=";
     };
     x86_64-linux = {
       url = "https://downloads.factory.ai/factory-cli/releases/${version}/linux/x64/droid";
-      hash = "sha256-tOjqNFBWeHqV/lSn6IMN9JA3boXf6QfXrbp/bEdLbwk=";
+      hash = "sha256-DodIEfuYTtgb/VaLooECAw+1/PUiB29jeagSRfoSBvw=";
     };
   };
 

--- a/config/home-manager/home/packages/gemini-cli.nix
+++ b/config/home-manager/home/packages/gemini-cli.nix
@@ -2,7 +2,7 @@
 
 let
   pname = "gemini-cli";
-  version = "0.42.0";
+  version = "0.44.1";
   assetName = "gemini-cli-bundle.zip";
   isArchive = lib.hasSuffix ".zip" assetName;
 in
@@ -12,7 +12,7 @@ pkgs.stdenv.mkDerivation rec {
   src = (if isArchive then pkgs.fetchzip else pkgs.fetchurl) (
     {
       url = "https://github.com/google-gemini/gemini-cli/releases/download/v${version}/${assetName}";
-      hash = "sha256-Qkb39ehFabpRGxqpl3wCzoK3A2z5TMnKswngLz6kP/s=";
+      hash = "sha256-pCNixlo5zSHl3E60kavXnKi0kEHLQGZCtz9crW5LO3Y=";
     }
     // lib.optionalAttrs isArchive {
       stripRoot = false;

--- a/config/home-manager/home/packages/stub-runfiles.patch
+++ b/config/home-manager/home/packages/stub-runfiles.patch
@@ -1,7 +1,7 @@
 diff -urN orig/Cargo.lock mod/Cargo.lock
 --- orig/Cargo.lock
 +++ mod/Cargo.lock
-@@ -11011,7 +11011,6 @@
+@@ -11178,7 +11178,6 @@
  [[package]]
  name = "runfiles"
  version = "0.1.0"
@@ -12,7 +12,7 @@ diff -urN orig/Cargo.lock mod/Cargo.lock
 diff -urN orig/Cargo.toml mod/Cargo.toml
 --- orig/Cargo.toml
 +++ mod/Cargo.toml
-@@ -340,7 +340,7 @@
+@@ -343,7 +343,7 @@
  regex-lite = "0.1.8"
  reqwest = { version = "0.12", features = ["cookies"] }
  rmcp = { version = "0.15.0", default-features = false }

--- a/flake.nix
+++ b/flake.nix
@@ -433,10 +433,18 @@
             claudius-skill-guardrails = {
               enable = true;
               name = "claudius-skill-guardrails";
-              entry = "${pkgs.bash}/bin/bash -c 'CLAUDIUS_BIN=${lib.getExe' pkgs.claudius "claudius"} ${pkgs.python3}/bin/python3 scripts/test-claudius-skills.py'";
+              entry = "${pkgs.bash}/bin/bash -c 'PATH=${pkgs.shfmt}/bin:$PATH CLAUDIUS_BIN=${lib.getExe' pkgs.claudius "claudius"} ${pkgs.python3}/bin/python3 scripts/test-claudius-skills.py'";
               language = "system";
               pass_filenames = false;
               files = "^config/claudius/skills/|^scripts/test-claudius-skills\\.py$";
+            };
+            codex-updater-regression = {
+              enable = true;
+              name = "codex-updater-regression";
+              entry = "${pkgs.python3}/bin/python3 scripts/test-update-codex-cli.py";
+              language = "system";
+              pass_filenames = false;
+              files = "^scripts/(update-codex-cli|test-update-codex-cli)\\.py$";
             };
             deadnix = {
               enable = true;

--- a/scripts/test-update-codex-cli.py
+++ b/scripts/test-update-codex-cli.py
@@ -1,0 +1,80 @@
+"""Regression tests for update-codex-cli helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_update_codex_cli() -> ModuleType:
+    module_path = Path(__file__).with_name("update-codex-cli.py")
+    scripts_dir = str(module_path.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    spec = importlib.util.spec_from_file_location("update_codex_cli", module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load {module_path}"
+        raise RuntimeError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _require_contains(needle: str, haystack: str, message: str) -> None:
+    if needle not in haystack:
+        raise AssertionError(message)
+
+
+def _require_not_contains(needle: str, haystack: str, message: str) -> None:
+    if needle in haystack:
+        raise AssertionError(message)
+
+
+def test_numeric_replacement_does_not_form_octal_backreference() -> None:
+    update_codex_cli = _load_update_codex_cli()
+    content = '\n  rustyV8Version = "146.4.0";\n'
+
+    updated = update_codex_cli._update_rusty_v8_version(content, "147.4.0")
+
+    _require_contains(
+        '  rustyV8Version = "147.4.0";',
+        updated,
+        "rustyV8Version was not updated correctly",
+    )
+    _require_not_contains(
+        "L7.4.0",
+        updated,
+        "numeric replacement formed an octal escape",
+    )
+
+
+def test_livekit_tag_replacement_preserves_prefix_and_suffix() -> None:
+    update_codex_cli = _load_update_codex_cli()
+    content = '\n  livekitWebRtcTag = "webrtc-24f6822-2";\n'
+
+    updated = update_codex_cli._update_livekit_webrtc_tag(
+        content,
+        "webrtc-1234567-3",
+    )
+
+    _require_contains(
+        '  livekitWebRtcTag = "webrtc-1234567-3";',
+        updated,
+        "livekitWebRtcTag was not updated correctly",
+    )
+
+
+def main() -> None:
+    test_numeric_replacement_does_not_form_octal_backreference()
+    test_livekit_tag_replacement_preserves_prefix_and_suffix()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-codex-cli.py
+++ b/scripts/update-codex-cli.py
@@ -377,7 +377,7 @@ def _release_asset_digest_hashes(
 
 def _update_rusty_v8_version(content: str, version: str) -> str:
     updated, replacements = _RUSTY_V8_VERSION_PATTERN.subn(
-        rf'\1{version}\3',
+        rf'\g<1>{version}\g<3>',
         content,
         count=1,
     )
@@ -389,7 +389,7 @@ def _update_rusty_v8_version(content: str, version: str) -> str:
 
 def _update_livekit_webrtc_tag(content: str, tag: str) -> str:
     updated, replacements = _LIVEKIT_WEBRTC_TAG_PATTERN.subn(
-        rf'\1{tag}\3',
+        rf'\g<1>{tag}\g<3>',
         content,
         count=1,
     )
@@ -441,7 +441,7 @@ def _update_rusty_v8_archive_hashes(
     updated_body = "\n".join(
         f'{entry_indent}{system} = "{hashes[system]}";'
         for system in _RUSTY_V8_TARGETS
-    )
+    ) + "\n"
     return content[:match.start("body")] + updated_body + content[match.end("body"):]
 
 
@@ -487,7 +487,7 @@ def _update_livekit_webrtc_zip_hashes(
     updated_body = "\n".join(
         f'{entry_indent}{system} = "{hashes[system]}";'
         for system in _LIVEKIT_WEBRTC_TRIPLES
-    )
+    ) + "\n"
     return content[:match.start("body")] + updated_body + content[match.end("body"):]
 
 

--- a/scripts/update_lib.py
+++ b/scripts/update_lib.py
@@ -310,7 +310,7 @@ def calculate_cargo_hash(nix_file: Path) -> Hash | None:  # noqa: C901, PLR0912,
         # Replace cargoHash with a dummy value
         dummy_content = re.sub(
             r'(cargoHash\s*=\s*")([^"]+)(")',
-            r'\1sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\3',
+            r'\g<1>sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\g<3>',
             content,
             flags=re.MULTILINE | re.DOTALL,
         )
@@ -700,7 +700,7 @@ def apply_updates(config: UpdateConfig, content: str, new_info: PackageInfo) -> 
             # Match the full line: cargoHash = "...";
             updated = re.sub(
                 r'(cargoHash\s*=\s*"[^"]+";)',
-                rf'\1\n    {new_comment}',
+                rf'\g<1>\n    {new_comment}',
                 updated,
             )
 


### PR DESCRIPTION
## Summary
- Fix Codex updater regex replacements so numeric versions like rusty_v8 147.4.0 do not become invalid octal-backreference output such as L7.4.0
- Add a regression hook for the Codex updater replacement path
- Apply the AI tools update that the repaired workflow now generates

## Verification
- python3 scripts/test-update-codex-cli.py
- ./scripts/update-ai-tools-all.sh
- ./scripts/build-ai-tools.sh
- nix develop --impure --command pre-commit run --all-files --show-diff-on-failure
- nix flake check --impure