### PR TITLE
fix(ai-tools): preserve codex cargo hash formatting

### DIFF
--- a/scripts/test-update-codex-cli.py
+++ b/scripts/test-update-codex-cli.py
@@ -71,9 +71,41 @@ def test_livekit_tag_replacement_preserves_prefix_and_suffix() -> None:
     )
 
 
+def test_cargo_hash_replacement_preserves_closing_brace_indent() -> None:
+    update_codex_cli = _load_update_codex_cli()
+    content = (
+        "let\n"
+        "  cargoHashes = {\n"
+        '    x86_64-linux = "sha256-old";\n'
+        '    aarch64-linux = "sha256-old";\n'
+        '    x86_64-darwin = "sha256-old";\n'
+        '    aarch64-darwin = "sha256-old";\n'
+        "  };\n"
+        "in\n"
+        "{}\n"
+    )
+
+    updated = update_codex_cli._update_cargo_hashes(
+        content,
+        "sha256-new",
+    )
+
+    _require_contains(
+        "\n  };\n",
+        updated,
+        "cargoHashes closing brace indentation was not preserved",
+    )
+    _require_not_contains(
+        "\n};\n",
+        updated,
+        "cargoHashes closing brace was moved to column zero",
+    )
+
+
 def main() -> None:
     test_numeric_replacement_does_not_form_octal_backreference()
     test_livekit_tag_replacement_preserves_prefix_and_suffix()
+    test_cargo_hash_replacement_preserves_closing_brace_indent()
 
 
 if __name__ == "__main__":

--- a/scripts/update-codex-cli.py
+++ b/scripts/update-codex-cli.py
@@ -664,6 +664,17 @@ def _update_cargo_hashes(
         block_indent = block_indent_match.group(1) if block_indent_match else ""
         entry_indent = f"{block_indent}  "
 
+    closing_indent_match = re.search(r"\n([ \t]*)\Z", body)
+    if closing_indent_match:
+        closing_indent = closing_indent_match.group(1)
+    else:
+        block_indent_match = re.search(
+            r'^(\s*)cargoHashes\s*=\s*{',
+            content,
+            re.MULTILINE,
+        )
+        closing_indent = block_indent_match.group(1) if block_indent_match else ""
+
     hashes = _extract_cargo_hashes(content)
     for system in systems:
         hashes[system] = new_hash
@@ -682,7 +693,7 @@ def _update_cargo_hashes(
     updated_body = "\n".join(
         f'{entry_indent}{supported_system} = "{hashes[supported_system]}";'
         for supported_system in [*ordered_systems, *remaining_systems]
-    ) + "\n"
+    ) + f"\n{closing_indent}"
 
     return content[:match.start("body")] + updated_body + content[match.end("body"):]
 


### PR DESCRIPTION
## Summary
- Preserve the closing indentation of the codex cargoHashes block when recalculating cargoHash values
- Add a regression test so forced macOS cargoHash refreshes do not create formatting-only changes

## Verification
- python3 scripts/test-update-codex-cli.py
- nix develop --impure --command pre-commit run --all-files --show-diff-on-failure
- nix flake check --impure