### PR TITLE
ci: use GitHub App token for automation PRs

### DIFF
--- a/.github/actions/create-automation-token/action.yml
+++ b/.github/actions/create-automation-token/action.yml
@@ -1,0 +1,96 @@
+name: Create automation token
+description: Create a least-privilege GitHub App installation token for automation PRs.
+
+inputs:
+  app-id:
+    description: GitHub App ID.
+    required: true
+  private-key:
+    description: GitHub App private key in PEM format.
+    required: true
+  installation-id:
+    description: GitHub App installation ID for this account or repository.
+    required: true
+
+outputs:
+  token:
+    description: GitHub App installation token.
+    value: ${{ steps.token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - id: token
+      shell: bash
+      env:
+        APP_ID: ${{ inputs.app-id }}
+        APP_PRIVATE_KEY: ${{ inputs.private-key }}
+        APP_INSTALLATION_ID: ${{ inputs.installation-id }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$APP_ID" ] || [ -z "$APP_PRIVATE_KEY" ] || [ -z "$APP_INSTALLATION_ID" ]; then
+          echo "GitHub App ID, private key, and installation ID are required." >&2
+          exit 1
+        fi
+
+        tmp_dir="$(mktemp -d)"
+        trap 'rm -rf "$tmp_dir"' EXIT
+
+        key_file="$tmp_dir/app-private-key.pem"
+        printf '%s\n' "$APP_PRIVATE_KEY" > "$key_file"
+        chmod 600 "$key_file"
+
+        b64url() {
+          openssl base64 -A | tr '+/' '-_' | tr -d '='
+        }
+
+        now="$(date +%s)"
+        iat="$((now - 60))"
+        exp="$((now + 540))"
+        header="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)"
+        payload="$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$iat" "$exp" "$APP_ID" | b64url)"
+        signature="$(
+          printf '%s.%s' "$header" "$payload" \
+            | openssl dgst -sha256 -sign "$key_file" -binary \
+            | b64url
+        )"
+        jwt="$header.$payload.$signature"
+
+        repo_name="${GITHUB_REPOSITORY#*/}"
+        request_body="$(
+          REPO_NAME="$repo_name" python3 - <<'PY'
+        import json
+        import os
+
+        print(json.dumps({
+            "repositories": [os.environ["REPO_NAME"]],
+            "permissions": {
+                "contents": "write",
+                "pull_requests": "write",
+            },
+        }))
+        PY
+        )"
+
+        response="$(
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $jwt" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data "$request_body" \
+            "https://api.github.com/app/installations/${APP_INSTALLATION_ID}/access_tokens"
+        )"
+        token="$(
+          printf '%s' "$response" \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["token"])'
+        )"
+
+        if [ -z "$token" ]; then
+          echo "Failed to create GitHub App installation token." >&2
+          exit 1
+        fi
+
+        echo "::add-mask::$token"
+        echo "token=$token" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-ai-tools.yml
+++ b/.github/workflows/update-ai-tools.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update-ai-tools:
@@ -19,8 +18,6 @@ jobs:
       - name: Checkout repository
         # actions/checkout v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Nix
         # DeterminateSystems/nix-installer-action v22
@@ -52,11 +49,21 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
+          token: ${{ steps.automation-token.outputs.token }}
           commit-message: "chore(ai-tools): update AI tools"
           title: "chore(ai-tools): update AI tools"
           body: |
@@ -70,9 +77,6 @@ jobs:
             Changes were generated automatically by the daily update workflow.
           branch: update-ai-tools
           delete-branch: true
-          labels: |
-            dependencies
-            automated
 
   update-ai-tools-macos:
     runs-on: macos-latest
@@ -84,7 +88,6 @@ jobs:
         # actions/checkout v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Fetch update branch if exists
@@ -126,11 +129,21 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
+          token: ${{ steps.automation-token.outputs.token }}
           commit-message: "chore(ai-tools): update AI tools"
           title: "chore(ai-tools): update AI tools"
           body: |
@@ -144,6 +157,3 @@ jobs:
             Changes were generated automatically by the daily update workflow.
           branch: update-ai-tools
           delete-branch: true
-          labels: |
-            dependencies
-            automated

--- a/.github/workflows/update-cursor.yml
+++ b/.github/workflows/update-cursor.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
@@ -17,8 +16,6 @@ jobs:
       - name: Checkout repository
         # actions/checkout v6
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Nix
         # DeterminateSystems/nix-installer-action v22
@@ -51,12 +48,21 @@ jobs:
         run: |
           nix build --impure .#packages.x86_64-linux.cursor --print-build-logs
 
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.automation-token.outputs.token }}
           commit-message: "chore(cursor): update Cursor AppImage"
           title: "chore(cursor): update Cursor AppImage"
           body: |
@@ -66,6 +72,3 @@ jobs:
             The workflow verified the updated Cursor package builds successfully before opening this PR.
           branch: update-cursor
           delete-branch: true
-          labels: |
-            dependencies
-            automated

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
@@ -38,12 +37,21 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.automation-token.outputs.token }}
           commit-message: "chore: update flake.lock"
           title: "chore: update flake.lock"
           body: |
@@ -51,8 +59,5 @@ jobs:
 
             This PR updates the following inputs to their latest versions.
             Please review the changes and ensure all tests pass before merging.
-          labels: |
-            dependencies
-            automated
           branch: update-flake-lock
           delete-branch: true

--- a/.github/workflows/update-vscode-extensions.yml
+++ b/.github/workflows/update-vscode-extensions.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
@@ -34,11 +33,30 @@ jobs:
       - name: Update VSCode Extensions
         run: python3 scripts/update-vscode-extensions.py
 
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.automation-token.outputs.token }}
           commit-message: "chore(vscode): update VSCode extensions"
           title: "chore(vscode): update VSCode extensions"
           body: |
@@ -48,6 +66,3 @@ jobs:
             from the Visual Studio Code marketplace.
           branch: update-vscode-extensions
           delete-branch: true
-          labels: |
-            dependencies
-            automated

--- a/.github/workflows/update-vscode-insiders.yml
+++ b/.github/workflows/update-vscode-insiders.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   update:
@@ -34,11 +33,30 @@ jobs:
       - name: Update VSCode Insiders
         run: python3 scripts/update-vscode-insiders.py
 
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create automation token
+        id: automation-token
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+          installation-id: ${{ secrets.AUTOMATION_APP_INSTALLATION_ID }}
+
       - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
         # peter-evans/create-pull-request v8
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.automation-token.outputs.token }}
           commit-message: "chore(vscode): update VSCode Insiders"
           title: "chore(vscode): update VSCode Insiders"
           body: |
@@ -48,6 +66,3 @@ jobs:
             Please ensure the build succeeds before merging.
           branch: update-vscode-insiders
           delete-branch: true
-          labels: |
-            dependencies
-            automated


### PR DESCRIPTION
## Summary
- reduce automatic update workflow `GITHUB_TOKEN` permissions to read-only
- create a short-lived GitHub App installation token only when an update PR is needed
- use the App token for `peter-evans/create-pull-request` so trusted automation PRs can trigger CI without manual workflow approval
- remove automatic labels to avoid requiring Issues write permission

## Verification
- `actionlint .github/workflows/*.yml`
- YAML load check for workflows and `.github/actions/create-automation-token/action.yml`
- `bash -n` on the extracted `create-automation-token` shell script
- fake API token generation smoke test
- `nix develop --impure --command pre-commit run --all-files --show-diff-on-failure`
- `nix flake check --impure`

## Required GitHub setup before relying on this workflow
1. Create a GitHub App dedicated to this repository, for example `dotfiles-automation-pr`.
2. Disable webhooks for the App.
3. Grant only these repository permissions: `Contents: Read and write`, `Pull requests: Read and write`, `Metadata: Read-only`.
4. Do not grant `Issues`, `Actions`, `Secrets`, `Administration`, or `Workflows` permissions.
5. Install the App only on `cariandrum22/dotfiles`.
6. Generate a private key for the App.
7. Add repository secrets: `AUTOMATION_APP_ID`, `AUTOMATION_APP_PRIVATE_KEY`, `AUTOMATION_APP_INSTALLATION_ID`.
8. Keep fork PR workflow approval restrictions enabled.
9. After merge and secret setup, run one update workflow manually and confirm the generated automation PR starts CI without manual workflow approval.
