### PR TITLE
fix(vscode): add Copilot native dependencies

### DIFF
--- a/config/home-manager/programs/vscode/default.nix
+++ b/config/home-manager/programs/vscode/default.nix
@@ -28,6 +28,16 @@ let
   inherit (metadata) commit;
   sha256 = metadata.sha256.${system} or (throw "No sha256 for system: ${system}");
 
+  # Copilot's bundled SDK ships native modules under resources/app/extensions.
+  # autoPatchelf needs these as build inputs to resolve NEEDED entries, and as
+  # runtime dependencies to keep the patched RPATHs available.
+  copilotSdkNativeDependencies = lib.optionals pkgs.stdenv.isLinux [
+    pkgs.libei
+    pkgs.libjpeg8.out
+    pkgs.pipewire
+    pkgs.xorg.libXtst
+  ];
+
   vscodeInsidersPackage = (pkgs.vscode.override { isInsiders = true; }).overrideAttrs (oldAttrs: rec {
     pname = "vscode-insiders";
     version = "${metadata.version}-${commit}";
@@ -41,12 +51,14 @@ let
       ++ [
         pkgs.krb5
       ]
+      ++ copilotSdkNativeDependencies
       ++ lib.optionals pkgs.stdenv.isLinux [
         pkgs.webkitgtk_4_1
         pkgs.libsoup_3
       ];
     runtimeDependencies = lib.optionals pkgs.stdenv.isLinux (
       oldAttrs.runtimeDependencies
+      ++ copilotSdkNativeDependencies
       ++ [
         pkgs.libsecret
         pkgs.musl


### PR DESCRIPTION
## Summary

- Add Copilot SDK native Linux dependencies to the VS Code Insiders derivation.
- Share the dependency list between `buildInputs` and `runtimeDependencies` so `auto-patchelf` can both resolve NEEDED entries and preserve runtime RPATHs.

## Root Cause

`vscode-insiders` started shipping Copilot SDK native modules under `resources/app/extensions/copilot`. On Linux, `computer.node` now needs `libXtst.so.6`, `libjpeg.so.8`, `libpipewire-0.3.so.0`, and `libei.so.1`. These were not available to `auto-patchelf` as search inputs, so full Home Manager generation builds failed.

## Verification

- `nix build --impure .#packages.x86_64-linux.default --print-build-logs`
- `nix build --impure .#packages.x86_64-linux.headless --print-build-logs`
- `nix develop --impure --command pre-commit run --all-files --show-diff-on-failure`
- `nix flake check --impure`
