### PR TITLE
fix(shell): restore terminal state after ssh

### DIFF
--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -591,11 +591,22 @@ fn ll {|@args| ls -lh $@args }
 fn la {|@args| ls -lha $@args }
 fn code {|@args| code-insiders $@args }
 
+# Restore terminal modes that can be left enabled after interrupted nested SSH.
+fn -restore-terminal-after-ssh {
+  try {
+    printf "\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[?u" >/dev/tty
+  } catch {
+  }
+}
+
 # Configure kitty ssh workaround
 if (has-external kitty) {
   fn ssh {|@args|
-    set E:TERM = xterm-256color
-    e:ssh $@args
+    try {
+      env TERM=xterm-256color ssh $@args
+    } finally {
+      -restore-terminal-after-ssh
+    }
   }
 }
 

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -104,9 +104,21 @@ if [ -d "$HOME/Go" ]
     set_path "$GOPATH/bin"
 end
 
+# Restore terminal modes that can be left enabled after interrupted nested SSH.
+function __restore_terminal_after_ssh
+    if test -w /dev/tty
+        printf '\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[?u' >/dev/tty 2>/dev/null
+    end
+end
+
 # Configure kitty
 if type -q kitty
-    alias ssh="TERM=xterm-256color $(which ssh)"
+    function ssh --wraps ssh
+        TERM=xterm-256color command ssh $argv
+        set -l status_code $status
+        __restore_terminal_after_ssh
+        return $status_code
+    end
 end
 
 # Configure atuin (shell history in SQLite)


### PR DESCRIPTION
## Summary
- restore terminal modes after SSH exits to recover from interrupted nested SSH sessions
- keep the Kitty TERM workaround scoped to the SSH process instead of mutating the parent Elvish environment
- replace the Fish SSH alias with a wrapper that preserves SSH exit status

## Verification
- fish --no-config --no-execute config/fish/config.fish
- elvish -norc -compileonly with the added SSH wrapper snippet
- nix develop --impure --command pre-commit run --all-files --show-diff-on-failure
- nix flake check
- git log -1 --show-signature --pretty=fuller