### PR TITLE
fix(shell): avoid terminal response during ssh cleanup

### DIFF
--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -594,7 +594,7 @@ fn code {|@args| code-insiders $@args }
 # Restore terminal modes that can be left enabled after interrupted nested SSH.
 fn -restore-terminal-after-ssh {
   try {
-    printf "\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[?u" >/dev/tty
+    printf "\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[<u\e[=0u" >/dev/tty
   } catch {
   }
 }

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -107,7 +107,7 @@ end
 # Restore terminal modes that can be left enabled after interrupted nested SSH.
 function __restore_terminal_after_ssh
     if test -w /dev/tty
-        printf '\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[?u' >/dev/tty 2>/dev/null
+        printf '\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[<u\e[=0u' >/dev/tty 2>/dev/null
     end
 end
 


### PR DESCRIPTION
## Summary
- replace the Kitty keyboard-protocol query sequence in SSH cleanup with non-query reset sequences
- avoid emitting terminal responses that can leak into the prompt after interrupted nested SSH sessions
- keep the existing SGR, cursor, mouse, bracketed-paste, and modifyOtherKeys cleanup behavior

## Verification
- fish --no-config --no-execute config/fish/config.fish
- elvish -norc -compileonly with the updated cleanup snippet
- git diff --check
- nix develop --impure --command pre-commit run --all-files --show-diff-on-failure
- nix flake check
- git log -1 --show-signature --pretty=fuller