### PR TITLE
fix(shell): fully reset kitty keyboard stack

### DIFF
--- a/config/elvish/rc.elv
+++ b/config/elvish/rc.elv
@@ -594,7 +594,7 @@ fn code {|@args| code-insiders $@args }
 # Restore terminal modes that can be left enabled after interrupted nested SSH.
 fn -restore-terminal-after-ssh {
   try {
-    printf "\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[<u\e[=0u" >/dev/tty
+    printf "\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[<1000u\e[=0;1u" >/dev/tty
   } catch {
   }
 }

--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -107,7 +107,7 @@ end
 # Restore terminal modes that can be left enabled after interrupted nested SSH.
 function __restore_terminal_after_ssh
     if test -w /dev/tty
-        printf '\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[<u\e[=0u' >/dev/tty 2>/dev/null
+        printf '\e[0m\e[?25h\e[?7h\e[?1l\e[?1000l\e[?1002l\e[?1003l\e[?1006l\e[?2004l\e[>4;0m\e[<1000u\e[=0;1u' >/dev/tty 2>/dev/null
     end
 end
 


### PR DESCRIPTION
## Summary
- pop the Kitty keyboard protocol stack aggressively after SSH exits
- explicitly reset keyboard-protocol flags with mode 1 to avoid stale CSI-u key-event fragments
- keep existing cleanup for SGR, cursor visibility, mouse reporting, bracketed paste, and modifyOtherKeys

## Context
Interrupted nested SSH sessions can leave Kitty keyboard protocol state enabled. This can leak CSI-u fragments such as `58;6u` into the next prompt.

## Verification
- fish --no-config --no-execute config/fish/config.fish
- elvish -norc -compileonly with the updated cleanup snippet
- git diff --check
- nix develop --impure --command pre-commit run --all-files --show-diff-on-failure
- nix flake check
- git log -1 --show-signature --pretty=fuller