### PR TITLE
fix(cursor): use current update endpoints

### DIFF
--- a/config/home-manager/home/packages/cursor.nix
+++ b/config/home-manager/home/packages/cursor.nix
@@ -1,14 +1,14 @@
 { pkgs, ... }:
 let
   pname = "cursor";
-  version = "3.8.11";
+  version = "3.9.16";
 
   # Fixed download URL - update this with update-cursor.py script
-  downloadUrl = "https://downloads.cursor.com/production/e56ad3440df06d22ca7501e65fd518e905486ef7/linux/x64/Cursor-3.8.11-x86_64.AppImage";
+  downloadUrl = "https://downloads.cursor.com/production/042b3c1a4c53f2c3808067f519fbfc67b72cad8b/linux/x64/Cursor-3.9.16-x86_64.AppImage";
 
   src = pkgs.fetchurl {
     url = downloadUrl;
-    hash = "sha256-K8MAPqgc6ZokWBAUeLFUCcTLgnFXe9nLlB6Krq6KORo=";
+    hash = "sha256-dG61VYGMHPip57ldzNICEi1yPc4s1dON+MlDGiKadKc=";
   };
   appimageContents = pkgs.appimageTools.extract { inherit pname version src; };
 in

--- a/flake.nix
+++ b/flake.nix
@@ -445,6 +445,14 @@
               pass_filenames = false;
               files = "^scripts/(update-codex-cli|test-update-codex-cli)\\.py$";
             };
+            cursor-updater-regression = {
+              enable = true;
+              name = "cursor-updater-regression";
+              entry = "${pkgs.python3}/bin/python3 scripts/test-update-cursor.py";
+              language = "system";
+              pass_filenames = false;
+              files = "^scripts/(update-cursor|test-update-cursor)\\.py$";
+            };
             deadnix = {
               enable = true;
               settings = {

--- a/scripts/test-update-cursor.py
+++ b/scripts/test-update-cursor.py
@@ -1,0 +1,113 @@
+"""Regression tests for update-cursor helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _require_equal(actual: object, expected: object, message: str) -> None:
+    if actual != expected:
+        raise AssertionError(message)
+
+
+def _require_endswith(value: str, suffix: str, message: str) -> None:
+    if not value.endswith(suffix):
+        raise AssertionError(message)
+
+
+def _load_update_cursor() -> ModuleType:
+    module_path = Path(__file__).with_name("update-cursor.py")
+    scripts_dir = str(module_path.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    spec = importlib.util.spec_from_file_location("update_cursor", module_path)
+    if spec is None or spec.loader is None:
+        msg = f"Could not load {module_path}"
+        raise RuntimeError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_zsync_url_is_normalized_to_appimage() -> None:
+    update_cursor = _load_update_cursor()
+    url = (
+        "https://downloads.cursor.com/production/"
+        "042b3c1a4c53f2c3808067f519fbfc67b72cad8b/linux/x64/"
+        "Cursor-3.9.16-x86_64.AppImage.zsync"
+    )
+
+    normalized = update_cursor._normalize_appimage_url(url)
+
+    _require_endswith(
+        normalized,
+        "Cursor-3.9.16-x86_64.AppImage",
+        "zsync URL was not normalized to the AppImage URL",
+    )
+
+
+def test_update_api_payload_uses_product_version_and_appimage_url() -> None:
+    update_cursor = _load_update_cursor()
+    payload = {
+        "version": "3.9.16",
+        "productVersion": "3.9.16",
+        "url": (
+            "https://downloads.cursor.com/production/"
+            "042b3c1a4c53f2c3808067f519fbfc67b72cad8b/linux/x64/"
+            "Cursor-3.9.16-x86_64.AppImage.zsync"
+        ),
+    }
+
+    metadata = update_cursor._metadata_from_update_payload(payload)
+
+    _require_equal(
+        metadata.version,
+        "3.9.16",
+        "productVersion was not used as the Cursor version",
+    )
+    _require_equal(
+        metadata.commit_sha,
+        "042b3c1a4c53f2c3808067f519fbfc67b72cad8b",
+        "commit SHA was not extracted from the immutable download URL",
+    )
+    _require_endswith(
+        metadata.download_url,
+        "Cursor-3.9.16-x86_64.AppImage",
+        "metadata URL was not normalized to the AppImage URL",
+    )
+
+
+def test_download_page_extracts_latest_linux_x64_url() -> None:
+    update_cursor = _load_update_cursor()
+    content = (
+        '<a href="https://api2.cursor.sh/updates/download/golden/linux-arm64/'
+        'cursor/3.9">Linux AppImage (ARM64)</a>'
+        '<a href="https://api2.cursor.sh/updates/download/golden/linux-x64/'
+        'cursor/3.9">Linux AppImage (x64)</a>'
+    )
+
+    url = update_cursor._extract_download_page_url(content)
+
+    _require_equal(
+        url,
+        "https://api2.cursor.sh/updates/download/golden/linux-x64/cursor/3.9",
+        "Linux x64 AppImage URL was not extracted from the download page",
+    )
+
+
+def main() -> None:
+    test_zsync_url_is_normalized_to_appimage()
+    test_update_api_payload_uses_product_version_and_appimage_url()
+    test_download_page_extracts_latest_linux_x64_url()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-cursor.py
+++ b/scripts/update-cursor.py
@@ -30,9 +30,14 @@ Environment:
 
 from __future__ import annotations
 
+import json
 import re
 import sys
-from typing import TYPE_CHECKING, NamedTuple
+from html import unescape
+from typing import TYPE_CHECKING, NamedTuple, override
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import HTTPRedirectHandler, build_opener, urlopen
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -41,13 +46,23 @@ if TYPE_CHECKING:
 import common
 
 # Constants
-CURSOR_API_URL = "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable"
+CURSOR_UPDATE_API_URL_TEMPLATE = (
+    "https://api2.cursor.sh/updates/api/update/linux-x64/cursor/{version}/stable"
+)
+CURSOR_DOWNLOAD_PAGE_URL = "https://cursor.com/download"
 RE_VERSION = re.compile(r'version = "([^"]+)"')
 RE_DOWNLOAD_URL = re.compile(r'downloadUrl = "([^"]+)"')
 RE_HASH = re.compile(r'hash = "([^"]+)"')
 RE_VERSION_IN_URL = re.compile(r'[Cc]ursor-(\d+\.\d+\.\d+)')
 RE_COMMIT_IN_URL = re.compile(r"/production/([0-9a-f]{40})/")
+RE_DOWNLOAD_PAGE_URL = re.compile(
+    r"https:(?:\\?/){2}api2\.cursor\.sh(?:\\?/)updates(?:\\?/)download"
+    r"(?:\\?/)golden(?:\\?/)linux-x64(?:\\?/)cursor(?:\\?/)[^\\\"<]+",
+)
 RETRY_ATTEMPTS = 3
+HTTP_NO_CONTENT = 204
+HTTP_REDIRECT_MIN = 300
+HTTP_REDIRECT_MAX = 400
 
 
 class CursorConfigError(common.ConfigError):
@@ -83,6 +98,31 @@ class CursorInfo(NamedTuple):
     commit_sha: str
 
 
+class CursorMetadata(NamedTuple):
+    """Cursor metadata before Nix hash calculation."""
+
+    download_url: str
+    version: str
+    commit_sha: str
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Return redirect responses without following large AppImage downloads."""
+
+    @override
+    def redirect_request(
+        self,
+        req: object,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> None:
+        """Disable urllib's automatic redirect handling."""
+        del req, fp, code, msg, headers, newurl
+
+
 # ----- Pure helpers ----------------------------------------------------------------
 
 
@@ -116,6 +156,24 @@ def _extract_commit_from_url(url: str) -> str:
     return match.group(1)
 
 
+def _normalize_appimage_url(url: str) -> str:
+    """Normalize Cursor download URLs to the AppImage artifact."""
+    return url.removesuffix(".zsync")
+
+
+def _cursor_update_api_url(current_version: str) -> str:
+    """Build Cursor update API URL for the currently packaged version."""
+    return CURSOR_UPDATE_API_URL_TEMPLATE.format(version=current_version)
+
+
+def _extract_download_page_url(content: str) -> str:
+    """Extract the latest Linux x64 AppImage redirect URL from Cursor's page."""
+    if (match := RE_DOWNLOAD_PAGE_URL.search(content)) is None:
+        msg = "Could not find Linux x64 AppImage download URL on Cursor download page"
+        raise CursorApiError(msg)
+    return unescape(match.group(0).replace("\\/", "/"))
+
+
 def _extract_api_string(
     payload: dict[str, object], field_name: str, *, required: bool = True,
 ) -> str | None:
@@ -145,6 +203,25 @@ def _validate_download_url(download_url: str, version: str, commit_sha: str) -> 
         raise CursorApiError(msg)
 
 
+def _metadata_from_update_payload(payload: dict[str, object]) -> CursorMetadata:
+    """Build Cursor metadata from the update API payload."""
+    raw_download_url = _extract_api_string(payload, "url")
+    if raw_download_url is None:
+        msg = "Cursor update API response is missing 'url'"
+        raise CursorApiError(msg)
+
+    download_url = _normalize_appimage_url(raw_download_url)
+    version = _extract_api_string(payload, "productVersion", required=False)
+    if version is None:
+        version = _extract_api_string(payload, "version", required=False)
+    if version is None:
+        version = _extract_version_from_url(download_url)
+
+    commit_sha = _extract_commit_from_url(download_url)
+    _validate_download_url(download_url, version, commit_sha)
+    return CursorMetadata(download_url, version, commit_sha)
+
+
 def _generate_nix_content(
     content: str, version: str, download_url: str, download_hash: str,
 ) -> str:
@@ -158,6 +235,64 @@ def _generate_nix_content(
 
 
 # ----- API interaction -------------------------------------------------------------
+
+
+def _fetch_optional_json(url: str) -> dict[str, object] | None:
+    """Fetch JSON, returning None when Cursor reports no update with an empty body."""
+    req = common.build_request(url, headers=common.JSON_HEADERS)
+    try:
+        with urlopen(req, timeout=common.HTTP_TIMEOUT) as resp:  # noqa: S310
+            body = resp.read().decode("utf-8").strip()
+            if resp.status == HTTP_NO_CONTENT or not body:
+                return None
+            data = json.loads(body)
+    except (HTTPError, URLError, json.JSONDecodeError) as exc:
+        raise common.FetchError(url, exc) from exc
+
+    if not isinstance(data, dict):
+        msg = f"Cursor update API response must be a JSON object: {url}"
+        raise CursorApiError(msg)
+    return data
+
+
+def _resolve_cursor_download_url(url: str) -> str:
+    """Resolve Cursor's lightweight download URL to the immutable AppImage URL."""
+    normalized_url = _normalize_appimage_url(url)
+    if "://api2.cursor.sh/updates/download/" not in normalized_url:
+        return normalized_url
+
+    opener = build_opener(_NoRedirectHandler)
+    req = common.build_request(normalized_url)
+    try:
+        with opener.open(req, timeout=common.HTTP_TIMEOUT) as resp:
+            return _normalize_appimage_url(resp.geturl())
+    except HTTPError as exc:
+        if HTTP_REDIRECT_MIN <= exc.code < HTTP_REDIRECT_MAX:
+            location = exc.headers.get("Location")
+            if location:
+                return _normalize_appimage_url(urljoin(normalized_url, location))
+        raise common.FetchError(normalized_url, exc) from exc
+    except URLError as exc:
+        raise common.FetchError(normalized_url, exc) from exc
+
+
+def _fetch_update_api_metadata(current_version: str) -> CursorMetadata | None:
+    """Fetch Cursor metadata from the current update API."""
+    payload = _fetch_optional_json(_cursor_update_api_url(current_version))
+    if payload is None:
+        return None
+    return _metadata_from_update_payload(payload)
+
+
+def _fetch_download_page_metadata() -> CursorMetadata:
+    """Fetch Cursor metadata from the public download page as a fallback."""
+    page_content = common.fetch_text(CURSOR_DOWNLOAD_PAGE_URL)
+    redirect_url = _extract_download_page_url(page_content)
+    download_url = _resolve_cursor_download_url(redirect_url)
+    version = _extract_version_from_url(download_url)
+    commit_sha = _extract_commit_from_url(download_url)
+    _validate_download_url(download_url, version, commit_sha)
+    return CursorMetadata(download_url, version, commit_sha)
 
 
 def _retry_logger(
@@ -176,41 +311,50 @@ def _retry_logger(
     return log_retry
 
 
-def fetch_latest_cursor_info(*, verbose: bool = True) -> CursorInfo:
+def fetch_latest_cursor_info(
+    current_version: str,
+    current_url: str,
+    current_hash: str,
+    *,
+    verbose: bool = True,
+) -> CursorInfo:
     """Fetch latest Cursor information from API."""
+    update_api_url = _cursor_update_api_url(current_version)
     if verbose:
-        print(f"Fetching Cursor API response from {CURSOR_API_URL}...")
+        print(f"Fetching Cursor update API response from {update_api_url}...")
 
-    data = common.retry_with_backoff(
-        lambda: common.fetch_json(CURSOR_API_URL),
-        retries=RETRY_ATTEMPTS,
-        exceptions=(common.FetchError,),
-        on_retry=_retry_logger("Cursor API metadata", verbose=verbose),
-    )
+    try:
+        metadata = common.retry_with_backoff(
+            lambda: _fetch_update_api_metadata(current_version),
+            retries=RETRY_ATTEMPTS,
+            exceptions=(common.FetchError,),
+            on_retry=_retry_logger("Cursor update API metadata", verbose=verbose),
+        )
+    except common.FetchError as exc:
+        if verbose:
+            print(f"  Cursor update API failed: {exc}")
+            print(f"  Falling back to {CURSOR_DOWNLOAD_PAGE_URL}...")
+        metadata = common.retry_with_backoff(
+            _fetch_download_page_metadata,
+            retries=RETRY_ATTEMPTS,
+            exceptions=(common.FetchError,),
+            on_retry=_retry_logger("Cursor download page metadata", verbose=verbose),
+        )
 
-    download_url = _extract_api_string(data, "downloadUrl")
-    if download_url is None:
-        msg = "Cursor API response is missing 'downloadUrl'"
-        raise CursorApiError(msg)
-
-    version = _extract_api_string(data, "version", required=False)
-    if version is None:
-        version = _extract_version_from_url(download_url)
-
-    commit_sha = _extract_api_string(data, "commitSha", required=False)
-    if commit_sha is None:
-        commit_sha = _extract_commit_from_url(download_url)
-
-    _validate_download_url(download_url, version, commit_sha)
+    if metadata is None:
+        commit_sha = _extract_commit_from_url(current_url)
+        if verbose:
+            print("  Cursor update API reports no newer version")
+        return CursorInfo(current_url, current_hash, current_version, commit_sha)
 
     if verbose:
-        print(f"  Version: {version}")
-        print(f"  Commit: {commit_sha}")
-        print(f"  Download URL: {download_url}")
+        print(f"  Version: {metadata.version}")
+        print(f"  Commit: {metadata.commit_sha}")
+        print(f"  Download URL: {metadata.download_url}")
         print("Fetching download hash...")
 
     download_hash = common.retry_with_backoff(
-        lambda: common.run_nix_prefetch_sri(download_url),
+        lambda: common.run_nix_prefetch_sri(metadata.download_url),
         retries=RETRY_ATTEMPTS,
         exceptions=(common.SubprocessError, common.PrefetchError),
         on_retry=_retry_logger("Cursor download hash", verbose=verbose),
@@ -219,7 +363,12 @@ def fetch_latest_cursor_info(*, verbose: bool = True) -> CursorInfo:
     if verbose:
         print(f"  Download hash: {download_hash}")
 
-    return CursorInfo(download_url, download_hash, version, commit_sha)
+    return CursorInfo(
+        metadata.download_url,
+        download_hash,
+        metadata.version,
+        metadata.commit_sha,
+    )
 
 
 # ----- File operations -------------------------------------------------------------
@@ -285,7 +434,12 @@ def update_cursor(*, verbose: bool = True) -> bool:  # noqa: C901 - Clear sequen
     # Get latest info
     if verbose:
         print("\nFetching latest Cursor information...")
-    latest_info = fetch_latest_cursor_info(verbose=verbose)
+    latest_info = fetch_latest_cursor_info(
+        current_version,
+        current_url,
+        current_hash,
+        verbose=verbose,
+    )
 
     # Check if update is needed
     if (


### PR DESCRIPTION
## Summary
- Replace the removed Cursor download API with the current api2 update endpoint
- Normalize .zsync update URLs to immutable AppImage URLs and add a download-page fallback
- Update Cursor AppImage metadata to 3.9.16 and add updater regression coverage

## Verification
- python3 scripts/test-update-cursor.py
- python3 scripts/update-cursor.py
- nix build --impure .#packages.x86_64-linux.cursor --print-build-logs
- nix develop --impure --command pre-commit run --all-files --show-diff-on-failure
- nix flake check --impure