### PR TITLE
fix(kitty): avoid broken Darwin unstable build

### DIFF
--- a/config/home-manager/programs/kitty.nix
+++ b/config/home-manager/programs/kitty.nix
@@ -2,7 +2,7 @@
 {
   programs.kitty = {
     enable = true;
-    package = pkgs.unstable.kitty;
+    package = if pkgs.stdenv.hostPlatform.isDarwin then pkgs.kitty else pkgs.unstable.kitty;
     settings = {
       font_family = "Fira Code Retina Nerd Font Complete Mono";
       font_size = "12.0";


### PR DESCRIPTION
## Summary
- use stable kitty on Darwin to avoid the unstable 0.47.4 cctools linker crash
- keep Linux on unstable kitty

## Verification
- nixfmt --check config/home-manager/programs/kitty.nix
- git diff --cached --check
- nix eval --impure --raw .#homeConfigurations.aarch64-darwin.config.programs.kitty.package.version
- nix build --impure --no-link .#homeConfigurations.aarch64-darwin.activationPackage