### PR TITLE
chore(git): replace signing key

### DIFF
--- a/config/home-manager/programs/git.nix
+++ b/config/home-manager/programs/git.nix
@@ -86,7 +86,7 @@ in
   programs.git = {
     enable = true;
     signing = {
-      key = "48F302B631525FA4D5A40106AC7AA4174AC64BA5";
+      key = "435C9CF0DE7A2C3900FB24357E622B43290C285E!";
       signByDefault = true;
     };
     lfs.enable = true;


### PR DESCRIPTION
## Summary
- replace the Git signing subkey with `435C9CF0DE7A2C3900FB24357E622B43290C285E!`
- retain default signing for commits and tags
- remove all references to the previous signing key

## Verification
- generated Git config has `commit.gpgSign = true` and `tag.gpgSign = true`
- Home Manager activation package builds successfully
- `nixfmt --check config/home-manager/programs/git.nix`
- `git diff --check`
- commit signature verified with the new key