### PR TITLE
feat(home-manager): add Snowflake CLI

### DIFF
--- a/config/home-manager/home/packages/default.nix
+++ b/config/home-manager/home/packages/default.nix
@@ -73,6 +73,7 @@
         ssm-session-manager-plugin
         eksctl
         google-cloud-sdk
+        snowflake-cli
         k6
         redis
 


### PR DESCRIPTION
## Summary
- add the official Snowflake CLI to shared Home Manager packages
- install the `snow` command on Linux and macOS

## Verification
- evaluated `snowflake-cli-3.13.1` in both Linux and macOS Home Manager package lists
- verified `snow --version` on macOS
- built the aarch64-darwin Home Manager activation package
- ran `nixfmt --check` and `git diff --check`
- verified the commit signature with the configured signing subkey