### PR TITLE
fix: restore AI tool and Cursor updates

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -201,6 +201,13 @@ rustPlatform.buildRustPackage (
 
     cargoHash = cargoHashes.${pkgs.stdenv.system};
 
+    # Build only the distributed CLI. Upstream's workspace also contains
+    # samples and test utilities that are not part of this package.
+    cargoBuildFlags = [
+      "-p"
+      "codex-cli"
+    ];
+
     cargoPatches = [
       ./stub-runfiles.patch
     ];

--- a/scripts/test-update-codex-cli.py
+++ b/scripts/test-update-codex-cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -102,10 +103,28 @@ def test_cargo_hash_replacement_preserves_closing_brace_indent() -> None:
     )
 
 
+def test_missing_optional_rust_sdks_source_is_supported() -> None:
+    update_codex_cli = _load_update_codex_cli()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        source_dir = Path(temp_dir)
+        (source_dir / "Cargo.lock").write_text(
+            '[[package]]\nname = "codex-cli"\nversion = "0.146.0"\n',
+            encoding="utf-8",
+        )
+
+        source = update_codex_cli._extract_rust_sdks_source(source_dir)
+
+    if source is not None:
+        msg = "missing optional rust-sdks source was not accepted"
+        raise AssertionError(msg)
+
+
 def main() -> None:
     test_numeric_replacement_does_not_form_octal_backreference()
     test_livekit_tag_replacement_preserves_prefix_and_suffix()
     test_cargo_hash_replacement_preserves_closing_brace_indent()
+    test_missing_optional_rust_sdks_source_is_supported()
 
 
 if __name__ == "__main__":

--- a/scripts/update-codex-cli.py
+++ b/scripts/update-codex-cli.py
@@ -531,14 +531,14 @@ def _calculate_rusty_v8_archive_hashes(version: str) -> dict[str, str]:
     }
 
 
-def _extract_rust_sdks_source(source_dir: Path) -> tuple[str, str]:
+def _extract_rust_sdks_source(source_dir: Path) -> tuple[str, str] | None:
+    """Return the optional LiveKit SDK source pinned by Codex."""
     cargo_lock = source_dir / "Cargo.lock"
     match = _LIVEKIT_WEBRTC_SOURCE_PATTERN.search(
         cargo_lock.read_text(encoding="utf-8"),
     )
     if not match:
-        msg = f"Could not find rust-sdks source in {cargo_lock}"
-        raise RuntimeError(msg)
+        return None
     return match.group("repo"), match.group("rev")
 
 
@@ -551,6 +551,13 @@ def _extract_upstream_livekit_webrtc_tag(repo: str, rev: str) -> str:
         msg = f"Could not find WEBRTC_TAG in rust-sdks {repo}@{rev}"
         raise RuntimeError(msg)
     return match.group(1)
+
+
+def _extract_optional_livekit_webrtc_tag(source_dir: Path) -> str | None:
+    rust_sdks_source = _extract_rust_sdks_source(source_dir)
+    if rust_sdks_source is None:
+        return None
+    return _extract_upstream_livekit_webrtc_tag(*rust_sdks_source)
 
 
 def _livekit_webrtc_archive_url(tag: str, system: str) -> str:
@@ -777,10 +784,9 @@ def _refresh_release_metadata(
             tarball_path = _download_release_tarball(latest_version, temp_root)
             source_dir = _extract_codex_source_tree(tarball_path, temp_root)
             rusty_v8_version = _extract_upstream_rusty_v8_version(source_dir)
-            rust_sdks_repo, rust_sdks_rev = _extract_rust_sdks_source(source_dir)
-            livekit_webrtc_tag = _extract_upstream_livekit_webrtc_tag(
-                rust_sdks_repo,
-                rust_sdks_rev,
+            livekit_webrtc_tag = (
+                _extract_optional_livekit_webrtc_tag(source_dir)
+                or livekit_webrtc_tag
             )
     elif not RUSTY_V8_PATCH_FILE.exists():
         _regenerate_rusty_v8_patch(latest_version)
@@ -793,13 +799,9 @@ def _refresh_release_metadata(
             rusty_v8_version = rusty_v8_version or _extract_upstream_rusty_v8_version(
                 source_dir,
             )
-            rust_sdks_repo, rust_sdks_rev = _extract_rust_sdks_source(source_dir)
             livekit_webrtc_tag = (
                 livekit_webrtc_tag
-                or _extract_upstream_livekit_webrtc_tag(
-                    rust_sdks_repo,
-                    rust_sdks_rev,
-                )
+                or _extract_optional_livekit_webrtc_tag(source_dir)
             )
 
     if rusty_v8_version is None or livekit_webrtc_tag is None:

--- a/scripts/update-cursor.py
+++ b/scripts/update-cursor.py
@@ -34,7 +34,7 @@ import json
 import re
 import sys
 from html import unescape
-from typing import TYPE_CHECKING, NamedTuple, override
+from typing import TYPE_CHECKING, NamedTuple
 from urllib.error import HTTPError, URLError
 from urllib.parse import urljoin
 from urllib.request import HTTPRedirectHandler, build_opener, urlopen
@@ -109,8 +109,7 @@ class CursorMetadata(NamedTuple):
 class _NoRedirectHandler(HTTPRedirectHandler):
     """Return redirect responses without following large AppImage downloads."""
 
-    @override
-    def redirect_request(
+    def redirect_request(  # noqa: PLR0913, PLR0917, PLR6301
         self,
         req: object,
         fp: object,


### PR DESCRIPTION
## Summary

- restore Cursor updater compatibility with the workflow's Python 3.11 runtime
- allow Codex releases that no longer pin the optional LiveKit `rust-sdks` source
- build only the distributed `codex-cli` package instead of unrelated workspace samples and test utilities
- add a regression test for Codex releases without the LiveKit SDK source

## Root causes

- `update-cursor.py` imported `typing.override`, which is only available in Python 3.12+, while the workflow uses Python 3.11
- Codex `rust-v0.146.0` removed its native LiveKit SDK dependency, but the updater treated that source as mandatory
- after metadata generation was fixed, the Nix package built the entire Codex workspace; an unrelated sample binary exceeded Rust's recursion limit

## Verification

- Python 3.11 updater regression tests
- full pre-commit suite
- `nix flake check --impure`
- actual Cursor update to 3.14.7 and Linux Nix build
- actual AI tool updates and Linux Nix builds:
  - Claude Code 2.1.220
  - Codex CLI rust-v0.146.0
  - Droid 0.185.0
  - Gemini CLI 0.53.0
