### PR TITLE
fix(darwin): handle nested Obsidian app bundle

### DIFF
--- a/config/home-manager/overlays/darwin-workarounds.nix
+++ b/config/home-manager/overlays/darwin-workarounds.nix
@@ -11,6 +11,7 @@
 # - pre-commit: test-only dotnet dependency triggers LLVM build
 # - direnv 2.37.1: fish test is killed on macOS (blocks direnv-elvish-hook)
 # - inetutils 2.7: clang format string error on macOS (blocks home-manager)
+# - Obsidian 1.13.4: DMG nests Obsidian.app under a versioned directory
 #
 # Note: tlaps is excluded on macOS via lib.optionals in default.nix
 # (vampire-5.0.0 build fails with clang on macOS)
@@ -52,6 +53,11 @@ if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
 
     # direnv's fish tests are flaky on macOS and block elvish hook generation.
     direnv = direnvNoCheck;
+
+    # Obsidian's DMG no longer places the application at the archive root.
+    obsidian = prev.obsidian.overrideAttrs (old: {
+      sourceRoot = "Obsidian ${old.version}-universal/Obsidian.app";
+    });
   }
 else
   { }


### PR DESCRIPTION
## Summary
- override the aarch64-darwin Obsidian source root for the versioned DMG directory
- keep the workaround scoped to the existing Darwin overlay
- document the upstream packaging regression for later removal

## Cause
Obsidian 1.13.4 stores `Obsidian.app` at `Obsidian 1.13.4-universal/Obsidian.app`, while the nixpkgs derivation expects it at the archive root.

## Verification
- built `homeConfigurations.aarch64-darwin.pkgs.obsidian` successfully
- verified the generated `Obsidian.app`, `obsidian`, and `obsidian-cli` executables
- `nix flake check --impure --no-build`
- relevant pre-commit hooks passed