### PR TITLE
fix(codex): build code mode host binary

### DIFF
--- a/config/home-manager/home/packages/codex.nix
+++ b/config/home-manager/home/packages/codex.nix
@@ -118,6 +118,15 @@ let
 
   rustyV8Version = "150.4.0";
 
+  # `codex-code-mode-runtime` turns on the v8 crate's `v8_enable_sandbox`
+  # feature (which implies pointer compression). denoland/rusty_v8 publishes no
+  # prebuilts for that flavor, so upstream Codex builds them itself and attaches
+  # them to its own `rusty-v8-v*` release. Mirror what upstream's
+  # `.github/actions/setup-rusty-v8` does and consume the same artifacts.
+  rustyV8Profile = "ptrcomp_sandbox_release";
+
+  rustyV8BaseUrl = "https://github.com/openai/codex/releases/download/rusty-v8-v${rustyV8Version}";
+
   rustyV8Targets = {
     x86_64-linux = "x86_64-unknown-linux-gnu";
     aarch64-linux = "aarch64-unknown-linux-gnu";
@@ -125,18 +134,33 @@ let
     aarch64-darwin = "aarch64-apple-darwin";
   };
 
+  rustyV8Target = rustyV8Targets.${pkgs.stdenv.system};
+
   rustyV8ArchiveHashes = {
-    x86_64-linux = "sha256-WGn9twcbHyHyAKl86X0gElh34PMc2ALtmd4sU/SIsGw=";
-    aarch64-linux = "sha256-txd9Uq0zNycv4NO453gjnIIalcJdWVnexiue/WVPfdM=";
-    x86_64-darwin = "sha256-5ex9E/kUgT6/IB1Ee/j9J2h7exkuFsR/KCb+VBUXHyk=";
-    aarch64-darwin = "sha256-zNj4FIW4IsWxiuun+d65KaM4LYasZzu/DzZvBod+axA=";
+    x86_64-linux = "sha256-o1x10fJuapg4haRbM0kKTr5U8FBQVosyuJz7QhswtYM=";
+    aarch64-linux = "sha256-0VF+7UBUaFNwKbAF1f6ZfsdNXI01H5FrOm3yC30oEbo=";
+    x86_64-darwin = "sha256-4Nm7ZOizoDTCkwyDly8/NXYCERSDQvoEB7OCUO8zCFY=";
+    aarch64-darwin = "sha256-AK27SHmISMd1UEQcaGc6XoUpuOG3PqvN7iMss5tA9KE=";
+  };
+
+  rustyV8SrcBindingHashes = {
+    x86_64-linux = "sha256-dyeCauR5vbZF6Acjn7EtH44uI956bPFvXuWSaQ0dhQY=";
+    aarch64-linux = "sha256-dyeCauR5vbZF6Acjn7EtH44uI956bPFvXuWSaQ0dhQY=";
+    x86_64-darwin = "sha256-ylrfDPicmnCtRgrnNkiy/om3SqETs8t/dXtqArdYOU8=";
+    aarch64-darwin = "sha256-ylrfDPicmnCtRgrnNkiy/om3SqETs8t/dXtqArdYOU8=";
   };
 
   rustyV8Archive = pkgs.fetchurl {
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${
-      rustyV8Targets.${pkgs.stdenv.system}
-    }.a.gz";
+    url = "${rustyV8BaseUrl}/librusty_v8_${rustyV8Profile}_${rustyV8Target}.a.gz";
     hash = rustyV8ArchiveHashes.${pkgs.stdenv.system};
+  };
+
+  # The v8 crate `include!`s the generated bindings instead of running bindgen,
+  # and only vendors the flavors it publishes itself. Supply the matching
+  # sandbox bindings so the build never reaches for the network.
+  rustyV8SrcBinding = pkgs.fetchurl {
+    url = "${rustyV8BaseUrl}/src_binding_${rustyV8Profile}_${rustyV8Target}.rs";
+    hash = rustyV8SrcBindingHashes.${pkgs.stdenv.system};
   };
 
   livekitWebRtcTag = "webrtc-24f6822-2";
@@ -201,11 +225,16 @@ rustPlatform.buildRustPackage (
 
     cargoHash = cargoHashes.${pkgs.stdenv.system};
 
-    # Build only the distributed CLI. Upstream's workspace also contains
-    # samples and test utilities that are not part of this package.
+    # Build the distributed CLI plus the Code Mode host helper. Upstream's
+    # workspace also contains samples and test utilities that are not part of
+    # this package. Since rust-v0.147.0 the CLI spawns `codex-code-mode-host`,
+    # which it resolves as a sibling of its own executable, so that binary has
+    # to land in the same `bin` directory.
     cargoBuildFlags = [
       "-p"
       "codex-cli"
+      "-p"
+      "codex-code-mode-host"
     ];
 
     cargoPatches = [
@@ -270,6 +299,7 @@ rustPlatform.buildRustPackage (
 
     # Keep rusty_v8 fully offline inside the Nix sandbox.
     RUSTY_V8_ARCHIVE = "${rustyV8Archive}";
+    RUSTY_V8_SRC_BINDING_PATH = "${rustyV8SrcBinding}";
 
     # Keep LiveKit WebRTC fully offline inside the Nix sandbox.
     LK_CUSTOM_WEBRTC = "${livekitWebRtcArchive}";

--- a/scripts/update-codex-cli.py
+++ b/scripts/update-codex-cli.py
@@ -2,9 +2,9 @@
 """Update codex-cli tool using functional programming style.
 
 This script updates codex-cli metadata in Nix and maintains per-platform
-cargoHashes, rusty_v8 archive hashes, and LiveKit WebRTC archive hashes. It
-fetches the latest version from GitHub releases and generates the appropriate
-hashes.
+cargoHashes, rusty_v8 prebuilt hashes (static archive plus generated bindings),
+and LiveKit WebRTC archive hashes. It fetches the latest version from GitHub
+releases and generates the appropriate hashes.
 
 Usage:
     ./update-codex-cli.py
@@ -39,7 +39,7 @@ import common
 import update_lib as lib
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
 # Path to the nix file
 NIX_FILE = Path("config/home-manager/home/packages/codex.nix")
@@ -60,7 +60,12 @@ CONFIG = lib.UpdateConfig(
 
 GITHUB_REPO = "openai/codex"
 VERSION_PREFIX = "rust-v"  # Codex uses "rust-v" prefix for versions
-_RUSTY_V8_GITHUB_REPO = "denoland/rusty_v8"
+# `codex-code-mode-runtime` enables the v8 crate's `v8_enable_sandbox` feature,
+# and denoland/rusty_v8 publishes no prebuilts for that flavor. Upstream Codex
+# builds them itself and attaches them to its own `rusty-v8-v*` release, so
+# follow `.github/actions/setup-rusty-v8` in openai/codex and use those assets.
+_RUSTY_V8_GITHUB_REPO = "openai/codex"
+_RUSTY_V8_PROFILE = "ptrcomp_sandbox_release"
 _LIVEKIT_RUST_SDKS_GITHUB_REPO = "livekit/rust-sdks"
 
 _SYSTEM_MAP = {
@@ -399,9 +404,10 @@ def _update_livekit_webrtc_tag(content: str, tag: str) -> str:
     return updated
 
 
-def _extract_rusty_v8_archive_hashes(content: str) -> dict[str, str]:
+def _extract_system_hashes(content: str, attr_name: str) -> dict[str, str]:
+    """Read a `system = "hash";` attrset from codex.nix."""
     match = re.search(
-        r'rustyV8ArchiveHashes\s*=\s*{\n(?P<body>.*?)};',
+        rf'{re.escape(attr_name)}\s*=\s*{{\n(?P<body>.*?)}};',
         content,
         re.DOTALL,
     )
@@ -417,6 +423,14 @@ def _extract_rusty_v8_archive_hashes(content: str) -> dict[str, str]:
             re.MULTILINE,
         )
     }
+
+
+def _extract_rusty_v8_archive_hashes(content: str) -> dict[str, str]:
+    return _extract_system_hashes(content, "rustyV8ArchiveHashes")
+
+
+def _extract_rusty_v8_src_binding_hashes(content: str) -> dict[str, str]:
+    return _extract_system_hashes(content, "rustyV8SrcBindingHashes")
 
 
 def _nix_attrset_indents(
@@ -449,86 +463,86 @@ def _nix_attrset_indents(
     return entry_indent, closing_indent
 
 
-def _update_rusty_v8_archive_hashes(
-    content: str, hashes: dict[str, str],
+def _update_system_hashes(
+    content: str,
+    attr_name: str,
+    hashes: dict[str, str],
+    systems: Iterable[str],
 ) -> str:
+    """Rewrite a `system = "hash";` attrset in codex.nix."""
     match = re.search(
-        r'rustyV8ArchiveHashes\s*=\s*{\n(?P<body>.*?)};',
+        rf'{re.escape(attr_name)}\s*=\s*{{\n(?P<body>.*?)}};',
         content,
         re.DOTALL,
     )
     if not match:
-        msg = "Could not find rustyV8ArchiveHashes block in codex.nix"
+        msg = f"Could not find {attr_name} block in codex.nix"
         raise ValueError(msg)
 
     body = match.group("body")
-    entry_indent, closing_indent = _nix_attrset_indents(
-        content,
-        body,
-        "rustyV8ArchiveHashes",
-    )
+    entry_indent, closing_indent = _nix_attrset_indents(content, body, attr_name)
     updated_body = "\n".join(
-        f'{entry_indent}{system} = "{hashes[system]}";'
-        for system in _RUSTY_V8_TARGETS
+        f'{entry_indent}{system} = "{hashes[system]}";' for system in systems
     ) + f"\n{closing_indent}"
     return content[:match.start("body")] + updated_body + content[match.end("body"):]
 
 
-def _extract_livekit_webrtc_zip_hashes(content: str) -> dict[str, str]:
-    match = re.search(
-        r'livekitWebRtcZipHashes\s*=\s*{\n(?P<body>.*?)};',
+def _update_rusty_v8_archive_hashes(
+    content: str, hashes: dict[str, str],
+) -> str:
+    return _update_system_hashes(
         content,
-        re.DOTALL,
+        "rustyV8ArchiveHashes",
+        hashes,
+        _RUSTY_V8_TARGETS,
     )
-    if not match:
-        return {}
 
-    body = match.group("body")
-    return {
-        entry.group(1): entry.group(2)
-        for entry in re.finditer(
-            r'^\s*([A-Za-z0-9_-]+)\s*=\s*"([^"]+)";',
-            body,
-            re.MULTILINE,
-        )
-    }
+
+def _update_rusty_v8_src_binding_hashes(
+    content: str, hashes: dict[str, str],
+) -> str:
+    return _update_system_hashes(
+        content,
+        "rustyV8SrcBindingHashes",
+        hashes,
+        _RUSTY_V8_TARGETS,
+    )
+
+
+def _extract_livekit_webrtc_zip_hashes(content: str) -> dict[str, str]:
+    return _extract_system_hashes(content, "livekitWebRtcZipHashes")
 
 
 def _update_livekit_webrtc_zip_hashes(
     content: str, hashes: dict[str, str],
 ) -> str:
-    match = re.search(
-        r'livekitWebRtcZipHashes\s*=\s*{\n(?P<body>.*?)};',
+    return _update_system_hashes(
         content,
-        re.DOTALL,
-    )
-    if not match:
-        msg = "Could not find livekitWebRtcZipHashes block in codex.nix"
-        raise ValueError(msg)
-
-    body = match.group("body")
-    entry_indent, closing_indent = _nix_attrset_indents(
-        content,
-        body,
         "livekitWebRtcZipHashes",
+        hashes,
+        _LIVEKIT_WEBRTC_TRIPLES,
     )
-    updated_body = "\n".join(
-        f'{entry_indent}{system} = "{hashes[system]}";'
-        for system in _LIVEKIT_WEBRTC_TRIPLES
-    ) + f"\n{closing_indent}"
-    return content[:match.start("body")] + updated_body + content[match.end("body"):]
 
 
-def _rusty_v8_archive_url(version: str, system: str) -> str:
-    target = _RUSTY_V8_TARGETS[system]
+def _rusty_v8_release_tag(version: str) -> str:
+    return f"rusty-v8-v{version}"
+
+
+def _rusty_v8_asset_url(version: str, name: str) -> str:
     return (
-        "https://github.com/denoland/rusty_v8/releases/download/"
-        f"v{version}/librusty_v8_release_{target}.a.gz"
+        f"https://github.com/{_RUSTY_V8_GITHUB_REPO}/releases/download/"
+        f"{_rusty_v8_release_tag(version)}/{name}"
     )
 
 
 def _rusty_v8_archive_name(system: str) -> str:
-    return f"librusty_v8_release_{_RUSTY_V8_TARGETS[system]}.a.gz"
+    target = _RUSTY_V8_TARGETS[system]
+    return f"librusty_v8_{_RUSTY_V8_PROFILE}_{target}.a.gz"
+
+
+def _rusty_v8_src_binding_name(system: str) -> str:
+    target = _RUSTY_V8_TARGETS[system]
+    return f"src_binding_{_RUSTY_V8_PROFILE}_{target}.rs"
 
 
 def _prefetch_file_hash(url: str) -> str:
@@ -543,18 +557,19 @@ def _prefetch_file_hash(url: str) -> str:
         raise RuntimeError(msg) from exc
 
 
-def _calculate_rusty_v8_archive_hashes(version: str) -> dict[str, str]:
+def _calculate_rusty_v8_asset_hashes(
+    version: str,
+    asset_name: Callable[[str], str],
+) -> dict[str, str]:
+    names = {system: asset_name(system) for system in _RUSTY_V8_TARGETS}
     asset_hashes = _release_asset_digest_hashes(
         _RUSTY_V8_GITHUB_REPO,
-        f"v{version}",
-        {
-            system: _rusty_v8_archive_name(system)
-            for system in _RUSTY_V8_TARGETS
-        },
+        _rusty_v8_release_tag(version),
+        names,
     )
     return {
         system: asset_hashes.get(system)
-        or _prefetch_file_hash(_rusty_v8_archive_url(version, system))
+        or _prefetch_file_hash(_rusty_v8_asset_url(version, names[system]))
         for system in _RUSTY_V8_TARGETS
     }
 
@@ -619,8 +634,14 @@ def _calculate_livekit_webrtc_zip_hashes(tag: str) -> dict[str, str]:
 def _needs_rusty_v8_update(content: str, version: str) -> bool:
     if _extract_rusty_v8_version(content) != version:
         return True
-    hashes = _extract_rusty_v8_archive_hashes(content)
-    return any(system not in hashes for system in _RUSTY_V8_TARGETS)
+    return any(
+        system not in hashes
+        for hashes in (
+            _extract_rusty_v8_archive_hashes(content),
+            _extract_rusty_v8_src_binding_hashes(content),
+        )
+        for system in _RUSTY_V8_TARGETS
+    )
 
 
 def _needs_livekit_webrtc_update(content: str, tag: str) -> bool:
@@ -823,9 +844,19 @@ def _refresh_rusty_v8_metadata(content: str, rusty_v8_version: str) -> str:
         return content
 
     updated_content = _update_rusty_v8_version(content, rusty_v8_version)
-    return _update_rusty_v8_archive_hashes(
+    updated_content = _update_rusty_v8_archive_hashes(
         updated_content,
-        _calculate_rusty_v8_archive_hashes(rusty_v8_version),
+        _calculate_rusty_v8_asset_hashes(
+            rusty_v8_version,
+            _rusty_v8_archive_name,
+        ),
+    )
+    return _update_rusty_v8_src_binding_hashes(
+        updated_content,
+        _calculate_rusty_v8_asset_hashes(
+            rusty_v8_version,
+            _rusty_v8_src_binding_name,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- build `codex-code-mode-host` alongside `codex-cli` so the CLI can spawn it
- source the rusty_v8 prebuilts from the upstream Codex release instead of denoland
- supply `RUSTY_V8_SRC_BINDING_PATH` so the v8 build stays offline in the sandbox
- teach the updater script to track the new release tag, profile, and binding hashes

## Cause
Codex `rust-v0.147.0` added Code Mode. The CLI resolves `codex-code-mode-host` as a sibling of its own executable (`codex-rs/install-context`), but `cargoBuildFlags` only built `-p codex-cli`, so the binary was never produced:

```
⚠ Code Mode is unavailable because failed to spawn code-mode host
  /nix/store/…/bin/codex-code-mode-host: host executable was not found.
```

Adding the crate then failed to compile `v8`, because `codex-code-mode-runtime` enables `v8_enable_sandbox` (which implies pointer compression). That selects the `ptrcomp_sandbox_release` flavor, which denoland/rusty_v8 does not publish and whose generated bindings are not vendored. Upstream builds those artifacts itself and attaches them to its own `rusty-v8-v*` release, as `.github/actions/setup-rusty-v8` shows.

## Verification
- built the package and confirmed `bin/codex`, `bin/codex-code-mode-host`, `bin/logs_client`
- `codex --version` → `codex-cli 0.147.0`
- `codex-code-mode-host --help` → `Usage: codex-code-mode-host [OPTIONS]`
- `cargoHash` unchanged; only the codex derivation rebuilt
- round-trip test of the updater hash extraction and rewriting
- `ruff check scripts/update-codex-cli.py`
- pre-commit suite (including `codex-updater-regression`)
