### PR TITLE
fix(darwin): remove stale Obsidian workaround

### DIFF
--- a/config/home-manager/overlays/darwin-workarounds.nix
+++ b/config/home-manager/overlays/darwin-workarounds.nix
@@ -11,7 +11,6 @@
 # - pre-commit: test-only dotnet dependency triggers LLVM build
 # - direnv 2.37.1: fish test is killed on macOS (blocks direnv-elvish-hook)
 # - inetutils 2.7: clang format string error on macOS (blocks home-manager)
-# - Obsidian 1.13.4: DMG nests Obsidian.app under a versioned directory
 #
 # Note: tlaps is excluded on macOS via lib.optionals in default.nix
 # (vampire-5.0.0 build fails with clang on macOS)
@@ -53,11 +52,6 @@ if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
 
     # direnv's fish tests are flaky on macOS and block elvish hook generation.
     direnv = direnvNoCheck;
-
-    # Obsidian's DMG no longer places the application at the archive root.
-    obsidian = prev.obsidian.overrideAttrs (old: {
-      sourceRoot = "Obsidian ${old.version}-universal/Obsidian.app";
-    });
   }
 else
   { }


### PR DESCRIPTION
## Summary
- remove the obsolete aarch64-darwin Obsidian `sourceRoot` override
- rely on the current nixpkgs package, which now handles the versioned DMG directory
- remove the resolved issue from the workaround inventory

## Cause
The previous workaround selected `Obsidian 1.13.4-universal/Obsidian.app` as the source root. Current nixpkgs already selects `Obsidian 1.13.4-universal` and its updated install phase copies `Obsidian.app`, so the local override made that path unavailable.

## Verification
- built `homeConfigurations.aarch64-darwin.pkgs.obsidian` successfully
- built `homeConfigurations.aarch64-darwin.activationPackage` successfully
- `nix flake check --impure --no-build`
- relevant pre-commit hooks passed