### PR TITLE
fix(wsl): enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

- enforce LF checkouts for all text files through `.gitattributes`
- prevent CRLF bytes from leaking into shell builders embedded in Nix multiline strings
- keep WSL checkouts under `/mnt/c` independent of Windows Git `core.autocrlf` defaults

## Failure addressed

`direnv-elvish-hook` failed with `$'\r': command not found` because the checkout converted `config/home-manager/programs/elvish.nix` to CRLF and Nix preserved the carriage return in the generated builder script.

## Verification

- `git add --renormalize .` produced no changes beyond `.gitattributes`
- `git check-attr text eol` reports `text=auto`, `eol=lf`
- `nix flake check --impure`
- directly realised the `direnv-elvish-hook` derivation successfully
